### PR TITLE
Refactor Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,3 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
-
-# VSCode settings
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+cov.xml
 
 # Translations
 *.mo
@@ -127,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode settings
+.vscode

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,6 +11,7 @@ from .discourse import Discourse
 from .docs_directory import read as read_docs_directory
 from .index import DOCUMENTATION_FOLDER_NAME
 from .index import get as get_index
+from .metadata import get as get_metadata
 from .navigation_table import from_page as navigation_table_from_page
 from .reconcile import run as run_reconcile
 
@@ -33,7 +34,8 @@ def run(
         All the URLs that had an action with the result of that action.
 
     """
-    index = get_index(base_path=base_path, server_client=discourse)
+    metadata = get_metadata(base_path)
+    index = get_index(metadata=metadata, base_path=base_path, server_client=discourse)
     path_infos = read_docs_directory(docs_path=base_path / DOCUMENTATION_FOLDER_NAME)
     server_content = (
         index.server.content if index.server is not None and index.server.content else ""

--- a/src/index.py
+++ b/src/index.py
@@ -7,8 +7,7 @@ from pathlib import Path
 
 from .discourse import Discourse
 from .exceptions import DiscourseError, ServerError
-from .metadata import get as get_metadata
-from .types_ import Index, IndexFile, Page
+from .types_ import Index, IndexFile, Metadata, Page
 
 DOCUMENTATION_FOLDER_NAME = "docs"
 DOCUMENTATION_INDEX_FILENAME = "index.md"
@@ -32,7 +31,7 @@ def _read_docs_index(base_path: Path) -> str | None:
     return index_file.read_text()
 
 
-def get(base_path: Path, server_client: Discourse) -> Index:
+def get(metadata: Metadata, base_path: Path, server_client: Discourse) -> Index:
     """Retrieve the local and server index information.
 
     Args:
@@ -46,8 +45,6 @@ def get(base_path: Path, server_client: Discourse) -> Index:
         ServerError: if interactions with the documentation server occurs.
 
     """
-    metadata = get_metadata(path=base_path)
-
     if metadata.docs is not None:
         index_url = metadata.docs
         try:

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -10,8 +10,8 @@ import yaml
 from . import types_
 from .exceptions import InputError
 
-METADATA_FILENAME = "metadata.yaml"
 METADATA_DOCS_KEY = "docs"
+METADATA_FILENAME = "metadata.yaml"
 METADATA_NAME_KEY = "name"
 
 

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -56,7 +56,7 @@ def get(path: Path) -> types_.Metadata:
         raise InputError(f"Invalid value for name key: {name}, expected a string value")
 
     docs = metadata.get(METADATA_DOCS_KEY)
-    if not isinstance(docs, str | None):
+    if not isinstance(docs, str | None) or (METADATA_DOCS_KEY in metadata and docs is None):
         raise InputError(f"Invalid value for docs key: {docs}, expected a string value")
 
     return types_.Metadata(name=name, docs=docs)

--- a/src/metadata.py
+++ b/src/metadata.py
@@ -1,0 +1,62 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for parsing metadata.yaml file."""
+
+from pathlib import Path
+
+import yaml
+
+from . import types_
+from .exceptions import InputError
+
+METADATA_FILENAME = "metadata.yaml"
+METADATA_DOCS_KEY = "docs"
+METADATA_NAME_KEY = "name"
+
+
+def get(path: Path) -> types_.Metadata:
+    """Check for and read the metadata.
+
+    Args:
+        path: The base path to look for the metadata file in.
+
+    Returns:
+        The contents of the metadata file.
+
+    Raises:
+        InputError: if the metadata file does not exists or is malformed.
+
+    """
+    metadata_yaml = path / METADATA_FILENAME
+    if not metadata_yaml.is_file():
+        raise InputError(f"Could not find {METADATA_FILENAME} file, looked in folder: {path}")
+
+    try:
+        metadata = yaml.safe_load(metadata_yaml.read_text())
+    except yaml.error.YAMLError as exc:
+        raise InputError(
+            f"Malformed {METADATA_FILENAME} file, read file: {metadata_yaml}"
+        ) from exc
+
+    if not metadata:
+        raise InputError(f"{METADATA_FILENAME} file is empty, read file: {metadata_yaml}")
+    if not isinstance(metadata, dict):
+        raise InputError(
+            f"{METADATA_FILENAME} file does not contain a mapping at the root, "
+            f"read file: {metadata_yaml}, content: {metadata!r}"
+        )
+
+    if METADATA_NAME_KEY not in metadata:
+        raise InputError(
+            f"Could not find required key: {METADATA_NAME_KEY}, "
+            f"read file: {metadata_yaml}, content: {metadata!r}"
+        )
+    if not isinstance(name := metadata[METADATA_NAME_KEY], str):
+        raise InputError(f"Invalid value for name key: {name}, expected a string value")
+
+    docs = metadata.get(METADATA_DOCS_KEY)
+    if not isinstance(docs, str | None):
+        raise InputError(f"Invalid value for docs key: {docs}, expected a string value")
+
+    return types_.Metadata(name=name, docs=docs)

--- a/src/types_.py
+++ b/src/types_.py
@@ -9,6 +9,25 @@ from enum import Enum
 from pathlib import Path
 from urllib.parse import urlparse
 
+
+class Metadata(typing.NamedTuple):
+    """Information within metadata file. Refer to: https://juju.is/docs/sdk/metadata-yaml.
+
+    Attrs:
+        name: Name of the charm.
+
+        docs: A link to a documentation cover page on Discourse.
+    """
+
+    # Required fields
+    # only name is required for the scope of this module
+    name: str
+
+    # Optional fields
+    # only docs is required for the scope of this module
+    docs: str | None
+
+
 Content = str
 Url = str
 

--- a/src/types_.py
+++ b/src/types_.py
@@ -13,18 +13,14 @@ from urllib.parse import urlparse
 class Metadata(typing.NamedTuple):
     """Information within metadata file. Refer to: https://juju.is/docs/sdk/metadata-yaml.
 
+    Only name and docs are the fields of interest for the scope of this module.
+
     Attrs:
         name: Name of the charm.
-
         docs: A link to a documentation cover page on Discourse.
     """
 
-    # Required fields
-    # only name is required for the scope of this module
     name: str
-
-    # Optional fields
-    # only docs is required for the scope of this module
     docs: str | None
 
 

--- a/tests/integration/test___init__.py
+++ b/tests/integration/test___init__.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 
 import pytest
 
-from src import exceptions, index, reconcile, run
+from src import exceptions, index, metadata, reconcile, run
 from src.discourse import Discourse
 
 from ..unit.helpers import assert_substrings_in_string, create_metadata_yaml
@@ -58,7 +58,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
         14. an index page is not updated
     """
     caplog.set_level(logging.INFO)
-    create_metadata_yaml(content=f"{index.METADATA_NAME_KEY}: name 1", path=tmp_path)
+    create_metadata_yaml(content=f"{metadata.METADATA_NAME_KEY}: name 1", path=tmp_path)
 
     # 1. docs empty
     urls_with_actions = run(
@@ -74,7 +74,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     # 2. docs with an index file in dry run mode
     caplog.clear()
     create_metadata_yaml(
-        content=f"{index.METADATA_NAME_KEY}: name 1\n{index.METADATA_DOCS_KEY}: {index_url}",
+        content=f"{metadata.METADATA_NAME_KEY}: name 1\n{metadata.METADATA_DOCS_KEY}: {index_url}",
         path=tmp_path,
     )
     (docs_dir := tmp_path / index.DOCUMENTATION_FOLDER_NAME).mkdir()

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,7 +6,7 @@
 import typing
 from pathlib import Path
 
-from src import index
+from src import metadata
 
 
 def create_metadata_yaml(content: str, path: Path) -> None:
@@ -17,7 +17,7 @@ def create_metadata_yaml(content: str, path: Path) -> None:
         path: The directory to create the file in.
 
     """
-    metadata_yaml = path / index.METADATA_FILENAME
+    metadata_yaml = path / metadata.METADATA_FILENAME
     metadata_yaml.write_text(content, encoding="utf-8")
 
 

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -6,7 +6,7 @@
 from pathlib import Path
 from unittest import mock
 
-from src import discourse, exceptions, index, reconcile, run, types_
+from src import discourse, exceptions, metadata, reconcile, run, types_
 
 from .helpers import create_metadata_yaml
 
@@ -17,7 +17,7 @@ def test_run_empty_local_server(tmp_path: Path):
     act: when run is called
     assert: then an index page is created with empty navigation table.
     """
-    create_metadata_yaml(content=f"{index.METADATA_NAME_KEY}: name 1", path=tmp_path)
+    create_metadata_yaml(content=f"{metadata.METADATA_NAME_KEY}: name 1", path=tmp_path)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.create_topic.return_value = (url := "url 1")
 
@@ -40,7 +40,7 @@ def test_run_local_empty_server(tmp_path: Path):
         page with a reference to the documentation page.
     """
     name = "name 1"
-    create_metadata_yaml(content=f"{index.METADATA_NAME_KEY}: {name}", path=tmp_path)
+    create_metadata_yaml(content=f"{metadata.METADATA_NAME_KEY}: {name}", path=tmp_path)
     (docs_folder := tmp_path / "docs").mkdir()
     (docs_folder / "index.md").write_text(index_content := "index content")
     (docs_folder / "page.md").write_text(page_content := "page content")
@@ -77,7 +77,7 @@ def test_run_local_empty_server_dry_run(tmp_path: Path):
     act: when run is called with dry run mode enabled
     assert: no pages are created.
     """
-    create_metadata_yaml(content=f"{index.METADATA_NAME_KEY}: name 1", path=tmp_path)
+    create_metadata_yaml(content=f"{metadata.METADATA_NAME_KEY}: name 1", path=tmp_path)
     (docs_folder := tmp_path / "docs").mkdir()
     (docs_folder / "index.md").write_text("index content")
     (docs_folder / "page.md").write_text("page content")
@@ -98,7 +98,7 @@ def test_run_local_empty_server_error(tmp_path: Path):
     act: when run is called
     assert: no pages are created.
     """
-    create_metadata_yaml(content=f"{index.METADATA_NAME_KEY}: name 1", path=tmp_path)
+    create_metadata_yaml(content=f"{metadata.METADATA_NAME_KEY}: name 1", path=tmp_path)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.create_topic.side_effect = exceptions.DiscourseError
 

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -11,102 +11,10 @@ from unittest import mock
 
 import pytest
 
-from src import discourse, index
-from src.exceptions import DiscourseError, InputError, ServerError
+from src import discourse, index, metadata
+from src.exceptions import DiscourseError, ServerError
 
 from .helpers import assert_substrings_in_string, create_metadata_yaml
-
-
-def test__get_metadata_metadata_yaml_missing(tmp_path: Path):
-    """
-    arrange: given empty directory
-    act: when _get_metadata is called with that directory
-    assert: then InputError is raised.
-    """
-    with pytest.raises(InputError) as exc_info:
-        index._get_metadata(path=tmp_path)
-
-    assert index.METADATA_FILENAME in str(exc_info.value).lower()
-
-
-@pytest.mark.parametrize(
-    "metadata_yaml_content, expected_error_msg_contents",
-    [
-        pytest.param("", ("empty", index.METADATA_FILENAME), id="malformed"),
-        pytest.param("malformed: yaml:", ("malformed", index.METADATA_FILENAME), id="malformed"),
-        pytest.param("value 1", ("not", "mapping", index.METADATA_FILENAME), id="not dict"),
-    ],
-)
-def test__get_metadata_metadata_yaml_malformed(
-    metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
-):
-    """
-    arrange: given directory with metadata.yaml that is malformed
-    act: when _get_metadata is called with the directory
-    assert: then InputError is raised.
-    """
-    create_metadata_yaml(content=metadata_yaml_content, path=tmp_path)
-
-    with pytest.raises(InputError) as exc_info:
-        index._get_metadata(path=tmp_path)
-
-    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
-
-
-def test__get_metadata_metadata(tmp_path: Path):
-    """
-    arrange: given directory with metadata.yaml with valid mapping yaml
-    act: when _get_metadata is called with the directory
-    assert: then file contents are returned as a dictionary.
-    """
-    create_metadata_yaml(content="key: value", path=tmp_path)
-
-    metadata = index._get_metadata(path=tmp_path)
-
-    assert metadata == {"key": "value"}
-
-
-@pytest.mark.parametrize(
-    "metadata, expected_error_msg_content",
-    [
-        pytest.param({}, "not defined", id="empty"),
-        pytest.param({"key": "value"}, "not defined", id="docs not defined"),
-        pytest.param({index.METADATA_DOCS_KEY: ""}, "empty", id="docs empty"),
-        pytest.param({index.METADATA_DOCS_KEY: 5}, "not a string", id="not string"),
-    ],
-)
-def test__get_key_docs_missing_malformed(metadata: dict, expected_error_msg_content: str):
-    """
-    arrange: given malformed metadata
-    act: when _get_key is called with the metadata
-    assert: then InputError is raised.
-    """
-    with pytest.raises(InputError) as exc_info:
-        index._get_key(metadata=metadata, key=index.METADATA_DOCS_KEY)
-
-    assert_substrings_in_string(
-        (
-            f"'{index.METADATA_DOCS_KEY}'",
-            expected_error_msg_content,
-            index.METADATA_FILENAME,
-            f"{metadata=!r}",
-        ),
-        str(exc_info.value).lower(),
-    )
-
-
-def test__get_key():
-    """
-    arrange: given metadata with docs key
-    act: when _get_key is called with the metadata
-    assert: then the docs value is returned.
-    """
-    docs_key = index.METADATA_DOCS_KEY
-    docs_value = "url 1"
-
-    returned_value = index._get_key(metadata={docs_key: docs_value}, key=docs_key)
-
-    assert returned_value == docs_value
 
 
 def test__read_docs_index_docs_directory_missing(tmp_path: Path):
@@ -153,7 +61,9 @@ def test_get_metadata_yaml_retrieve_discourse_error(tmp_path: Path):
     assert: then ServerError is raised.
     """
     create_metadata_yaml(
-        content=f"{index.METADATA_DOCS_KEY}: http://server/index-page", path=tmp_path
+        content=f"{metadata.METADATA_NAME_KEY}: name\n"
+        f"{metadata.METADATA_DOCS_KEY}: http://server/index-page",
+        path=tmp_path,
     )
     mocked_server_client = mock.MagicMock(spec=discourse.Discourse)
     mocked_server_client.retrieve_topic.side_effect = DiscourseError
@@ -175,7 +85,7 @@ def test_get_metadata_yaml_retrieve_local_and_server(tmp_path: Path, index_file_
     url = "http://server/index-page"
     name = "name 1"
     create_metadata_yaml(
-        content=f"{index.METADATA_DOCS_KEY}: {url}\n{index.METADATA_NAME_KEY}: {name}",
+        content=f"{metadata.METADATA_DOCS_KEY}: {url}\n{metadata.METADATA_NAME_KEY}: {name}",
         path=tmp_path,
     )
     mocked_server_client = mock.MagicMock(spec=discourse.Discourse)
@@ -199,7 +109,7 @@ def test_get_metadata_yaml_retrieve_empty(tmp_path: Path):
     assert: then all information is None except the title.
     """
     name = "name 1"
-    create_metadata_yaml(content=f"{index.METADATA_NAME_KEY}: {name}", path=tmp_path)
+    create_metadata_yaml(content=f"{metadata.METADATA_NAME_KEY}: {name}", path=tmp_path)
     mocked_server_client = mock.MagicMock(spec=discourse.Discourse)
 
     returned_index = index.get(base_path=tmp_path, server_client=mocked_server_client)

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -50,6 +50,43 @@ def test_get_yaml_malformed(
     assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
 
 
+@pytest.mark.parametrize(
+    "metadata_yaml_content, expected_error_msg_contents",
+    [
+        pytest.param("key: value", ("could not find", metadata.METADATA_NAME_KEY)),
+        pytest.param(
+            f"{metadata.METADATA_NAME_KEY}: 1",
+            (
+                "invalid value for",
+                metadata.METADATA_NAME_KEY,
+            ),
+        ),
+        pytest.param(
+            f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: 1",
+            ("invalid value for", metadata.METADATA_DOCS_KEY),
+        ),
+        pytest.param(
+            f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: ",
+            ("invalid value for", metadata.METADATA_DOCS_KEY),
+        ),
+    ],
+)
+def test_get_invalid_metadata(
+    metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
+):
+    """
+    arrange: given metadata with missing required keys
+    act: when get is called with the directory
+    assert: InputError is raised with missing keys info.
+    """
+    create_metadata_yaml(content=metadata_yaml_content, path=tmp_path)
+
+    with pytest.raises(exceptions.InputError) as exc_info:
+        metadata.get(path=tmp_path)
+
+    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
+
+
 # pylint currently does not understand walrus operator perfectly yet
 # pylint: disable=unused-variable,undefined-variable
 @pytest.mark.parametrize(
@@ -87,40 +124,3 @@ def test_get(
     data = metadata.get(path=tmp_path)
 
     assert data == expected_metadata
-
-
-@pytest.mark.parametrize(
-    "metadata_yaml_content, expected_error_msg_contents",
-    [
-        pytest.param("key: value", ("could not find", metadata.METADATA_NAME_KEY)),
-        pytest.param(
-            f"{metadata.METADATA_NAME_KEY}: 1",
-            (
-                "invalid value for",
-                metadata.METADATA_NAME_KEY,
-            ),
-        ),
-        pytest.param(
-            f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: 1",
-            ("invalid value for", metadata.METADATA_DOCS_KEY),
-        ),
-        pytest.param(
-            f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: ",
-            ("invalid value for", metadata.METADATA_DOCS_KEY),
-        ),
-    ],
-)
-def test_get_invalid_metadata(
-    metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
-):
-    """
-    arrange: given metadata with missing required keys
-    act: when get is called with the directory
-    assert: InputError is raised with missing keys info.
-    """
-    create_metadata_yaml(content=metadata_yaml_content, path=tmp_path)
-
-    with pytest.raises(exceptions.InputError) as exc_info:
-        metadata.get(path=tmp_path)
-
-    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -75,7 +75,7 @@ def test_get_invalid_metadata(
     metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
 ):
     """
-    arrange: given metadata with missing required keys
+    arrange: given metadata with missing required keys or invalid value
     act: when get is called with the directory
     assert: InputError is raised with missing keys info.
     """

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -53,28 +53,25 @@ def test_get_yaml_malformed(
 # pylint currently does not understand walrus operator perfectly yet
 # pylint: disable=unused-variable,undefined-variable
 @pytest.mark.parametrize(
-    "metadata_yaml_content, expected_metadata_name, expected_metadata_docs",
+    "metadata_yaml_content, expected_metadata",
     [
         pytest.param(
             f"{metadata.METADATA_NAME_KEY}: {(name := 'name')}",
-            name,
-            None,
+            types_.Metadata(name=name, docs=None),
             id="name only",
         ),
         pytest.param(
             f"{metadata.METADATA_NAME_KEY}: {name}\n"
             f"{metadata.METADATA_DOCS_KEY}: "
             f"{(docs := 'https://discourse.charmhub.io/t/index/1')}",
-            name,
-            docs,
+            types_.Metadata(name=name, docs=docs),
             id="name and docs",
         ),
     ],
 )
 def test_get(
     metadata_yaml_content: str,
-    expected_metadata_name: str,
-    expected_metadata_docs: str | None,
+    expected_metadata: types_.Metadata,
     tmp_path: Path,
 ):
     """
@@ -89,7 +86,7 @@ def test_get(
 
     data = metadata.get(path=tmp_path)
 
-    assert data == types_.Metadata(name=expected_metadata_name, docs=expected_metadata_docs)
+    assert data == expected_metadata
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -1,0 +1,111 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for metadata module."""
+
+from pathlib import Path
+
+import pytest
+
+from src import exceptions, metadata, types_
+
+from .helpers import assert_substrings_in_string, create_metadata_yaml
+
+
+def test_get_yaml_missing(tmp_path: Path):
+    """
+    arrange: given empty directory
+    act: when get is called with that directory
+    assert: then InputError is raised.
+    """
+    with pytest.raises(exceptions.InputError) as exc_info:
+        metadata.get(path=tmp_path)
+
+    assert metadata.METADATA_FILENAME in str(exc_info.value).lower()
+
+
+@pytest.mark.parametrize(
+    "metadata_yaml_content, expected_error_msg_contents",
+    [
+        pytest.param("", ("empty", metadata.METADATA_FILENAME), id="malformed"),
+        pytest.param(
+            "malformed: yaml:", ("malformed", metadata.METADATA_FILENAME), id="malformed"
+        ),
+        pytest.param("value 1", ("not", "mapping", metadata.METADATA_FILENAME), id="not dict"),
+    ],
+)
+def test_get_yaml_malformed(
+    metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
+):
+    """
+    arrange: given directory with metadata.yaml that is malformed
+    act: when get is called with the directory
+    assert: then InputError is raised.
+    """
+    create_metadata_yaml(content=metadata_yaml_content, path=tmp_path)
+
+    with pytest.raises(exceptions.InputError) as exc_info:
+        metadata.get(path=tmp_path)
+
+    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())
+
+
+@pytest.mark.parametrize(
+    "metadata_name, metadata_docs_url",
+    [
+        pytest.param("name", "", id="name only"),
+        pytest.param("name", "https://discourse.charmhub.io/t/index/1", id="name with docs"),
+    ],
+)
+def test_get(metadata_name: str, metadata_docs_url: str, tmp_path: Path):
+    """
+    arrange: given directory with metadata.yaml with valid metadata yaml
+    act: when get is called with the directory
+    assert: then file contents are returned as a dictionary.
+    """
+    metadata_docs_line = (
+        f"{metadata.METADATA_DOCS_KEY}: {metadata_docs_url}\n" if metadata_docs_url else ""
+    )
+    create_metadata_yaml(
+        content=f"{metadata.METADATA_NAME_KEY}: {metadata_name}\n"
+        f"{metadata_docs_line}"
+        "key: value",
+        path=tmp_path,
+    )
+
+    data = metadata.get(path=tmp_path)
+
+    assert data == types_.Metadata(name=metadata_name, docs=metadata_docs_url or None)
+
+
+@pytest.mark.parametrize(
+    "metadata_yaml_content, expected_error_msg_contents",
+    [
+        pytest.param("key: value", ("could not find", metadata.METADATA_NAME_KEY)),
+        pytest.param(
+            f"{metadata.METADATA_NAME_KEY}: 1",
+            (
+                "invalid value for",
+                metadata.METADATA_NAME_KEY,
+            ),
+        ),
+        pytest.param(
+            f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: 1",
+            ("invalid value for", metadata.METADATA_DOCS_KEY),
+        ),
+    ],
+)
+def test_get_invalid_metadata(
+    metadata_yaml_content: str, expected_error_msg_contents: tuple[str, ...], tmp_path: Path
+):
+    """
+    arrange: given metadata with missing required keys
+    act: when get is called with the directory
+    assert: InputError is raised with missing keys info.
+    """
+    create_metadata_yaml(content=metadata_yaml_content, path=tmp_path)
+
+    with pytest.raises(exceptions.InputError) as exc_info:
+        metadata.get(path=tmp_path)
+
+    assert_substrings_in_string(expected_error_msg_contents, str(exc_info.value).lower())

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -107,6 +107,10 @@ def test_get(
             f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: 1",
             ("invalid value for", metadata.METADATA_DOCS_KEY),
         ),
+        pytest.param(
+            f"{metadata.METADATA_NAME_KEY}: name\n{metadata.METADATA_DOCS_KEY}: ",
+            ("invalid value for", metadata.METADATA_DOCS_KEY),
+        ),
     ],
 )
 def test_get_invalid_metadata(


### PR DESCRIPTION
This PR is a refactor PR in preparation for https://github.com/canonical/upload-charm-docs/issues/9, Migration for existing docs.

Changes:

- change metadata dict to metadata dataclass
- add metadata required fields (name & docs key)
- add metadata required fields testing