### PR TITLE
remove type_ attribute and use type instead

### DIFF
--- a/src/action.py
+++ b/src/action.py
@@ -274,12 +274,15 @@ def _run_index(
     logging.info("dry run: %s, action: %s", dry_run, action)
 
     if dry_run:
-        if isinstance(action, types_.CreateIndexAction):
-            url = DRY_RUN_NAVLINK_LINK
-        else:
-            url = action.url
         report = types_.ActionReport(
-            table_row=None, url=url, result=types_.ActionResult.SKIP, reason=DRY_RUN_REASON
+            table_row=None,
+            url=(
+                DRY_RUN_NAVLINK_LINK
+                if isinstance(action, types_.CreateIndexAction)
+                else action.url
+            ),
+            result=types_.ActionResult.SKIP,
+            reason=DRY_RUN_REASON,
         )
         logging.info("report: %s", report)
         return report

--- a/src/reconcile.py
+++ b/src/reconcile.py
@@ -27,7 +27,6 @@ def _local_only(path_info: types_.PathInfo) -> types_.CreateAction:
         A page create action.
     """
     return types_.CreateAction(
-        type_=types_.ActionType.CREATE,
         level=path_info.level,
         path=path_info.table_path,
         navlink_title=path_info.navlink_title,
@@ -82,7 +81,6 @@ def _local_and_server(
         if table_row.navlink.title == path_info.navlink_title:
             return (
                 types_.NoopAction(
-                    type_=types_.ActionType.NOOP,
                     level=path_info.level,
                     path=path_info.table_path,
                     navlink=table_row.navlink,
@@ -91,7 +89,6 @@ def _local_and_server(
             )
         return (
             types_.UpdateAction(
-                type_=types_.ActionType.UPDATE,
                 level=path_info.level,
                 path=path_info.table_path,
                 navlink_change=types_.NavlinkChange(
@@ -114,14 +111,12 @@ def _local_and_server(
             )
         return (
             types_.DeleteAction(
-                type_=types_.ActionType.DELETE,
                 level=path_info.level,
                 path=path_info.table_path,
                 navlink=table_row.navlink,
                 content=discourse.retrieve_topic(url=table_row.navlink.link),
             ),
             types_.CreateAction(
-                type_=types_.ActionType.CREATE,
                 level=path_info.level,
                 path=path_info.table_path,
                 navlink_title=path_info.navlink_title,
@@ -135,7 +130,6 @@ def _local_and_server(
     if table_row.is_group:
         return (
             types_.CreateAction(
-                type_=types_.ActionType.CREATE,
                 level=path_info.level,
                 path=path_info.table_path,
                 navlink_title=path_info.navlink_title,
@@ -157,7 +151,6 @@ def _local_and_server(
     if server_content == local_content and table_row.navlink.title == path_info.navlink_title:
         return (
             types_.NoopAction(
-                type_=types_.ActionType.NOOP,
                 level=path_info.level,
                 path=path_info.table_path,
                 navlink=table_row.navlink,
@@ -166,7 +159,6 @@ def _local_and_server(
         )
     return (
         types_.UpdateAction(
-            type_=types_.ActionType.UPDATE,
             level=path_info.level,
             path=path_info.table_path,
             navlink_change=types_.NavlinkChange(
@@ -194,7 +186,6 @@ def _server_only(table_row: types_.TableRow, discourse: Discourse) -> types_.Del
     # Group case
     if table_row.is_group:
         return types_.DeleteAction(
-            type_=types_.ActionType.DELETE,
             level=table_row.level,
             path=table_row.path,
             navlink=table_row.navlink,
@@ -208,7 +199,6 @@ def _server_only(table_row: types_.TableRow, discourse: Discourse) -> types_.Del
             f"internal error, expecting link on table row, {table_row=!r}"
         )
     return types_.DeleteAction(
-        type_=types_.ActionType.DELETE,
         level=table_row.level,
         path=table_row.path,
         navlink=table_row.navlink,
@@ -312,17 +302,12 @@ def index_page(
     )
 
     if index.server is None:
-        return types_.CreateIndexAction(
-            type_=types_.ActionType.CREATE, content=local_content, title=index.local.title
-        )
+        return types_.CreateIndexAction(content=local_content, title=index.local.title)
 
     server_content = index.server.content.strip()
     if local_content != server_content:
         return types_.UpdateIndexAction(
-            type_=types_.ActionType.UPDATE,
             content_change=types_.IndexContentChange(old=server_content, new=local_content),
             url=index.server.url,
         )
-    return types_.NoopIndexAction(
-        type_=types_.ActionType.NOOP, content=local_content, url=index.server.url
-    )
+    return types_.NoopIndexAction(content=local_content, url=index.server.url)

--- a/src/types_.py
+++ b/src/types_.py
@@ -123,12 +123,7 @@ TableRowLookup = dict[tuple[Level, TablePath], TableRow]
 
 
 @dataclasses.dataclass
-class BaseAction:
-    """Represents an action on a page."""
-
-
-@dataclasses.dataclass
-class CreateAction(BaseAction):
+class CreateAction:
     """Represents a page to be created.
 
     Attrs:
@@ -145,7 +140,7 @@ class CreateAction(BaseAction):
 
 
 @dataclasses.dataclass
-class CreateIndexAction(BaseAction):
+class CreateIndexAction:
     """Represents an index page to be created.
 
     Attrs:
@@ -158,7 +153,7 @@ class CreateIndexAction(BaseAction):
 
 
 @dataclasses.dataclass
-class NoopAction(BaseAction):
+class NoopAction:
     """Represents a page with no required changes.
 
     Attrs:
@@ -175,7 +170,7 @@ class NoopAction(BaseAction):
 
 
 @dataclasses.dataclass
-class NoopIndexAction(BaseAction):
+class NoopIndexAction:
     """Represents an index page with no required changes.
 
     Attrs:
@@ -224,7 +219,7 @@ class IndexContentChange(typing.NamedTuple):
 
 
 @dataclasses.dataclass
-class UpdateAction(BaseAction):
+class UpdateAction:
     """Represents a page to be updated.
 
     Attrs:
@@ -241,7 +236,7 @@ class UpdateAction(BaseAction):
 
 
 @dataclasses.dataclass
-class UpdateIndexAction(BaseAction):
+class UpdateIndexAction:
     """Represents an index page to be updated.
 
     Attrs:
@@ -254,7 +249,7 @@ class UpdateIndexAction(BaseAction):
 
 
 @dataclasses.dataclass
-class DeleteAction(BaseAction):
+class DeleteAction:
     """Represents a page to be deleted.
 
     Attrs:

--- a/src/types_.py
+++ b/src/types_.py
@@ -122,31 +122,9 @@ class TableRow(typing.NamedTuple):
 TableRowLookup = dict[tuple[Level, TablePath], TableRow]
 
 
-class ActionType(str, Enum):
-    """The possible actions to take for a page.
-
-    Attrs:
-        CREATE: create a new page.
-        NOOP: no action required.
-        UPDATE: change aspects of an existing page.
-        DELETE: remove an existing page.
-    """
-
-    CREATE = "create"
-    NOOP = "noop"
-    UPDATE = "update"
-    DELETE = "delete"
-
-
 @dataclasses.dataclass
 class BaseAction:
-    """Represents an action on a page.
-
-    Attrs:
-        type_: The type of action to execute on the page.
-    """
-
-    type_: ActionType
+    """Represents an action on a page."""
 
 
 @dataclasses.dataclass
@@ -159,8 +137,6 @@ class CreateAction(BaseAction):
         navlink_title: The title of the navlink.
         content: The documentation content, is None for directories.
     """
-
-    type_: typing.Literal[ActionType.CREATE]
 
     level: Level
     path: TablePath
@@ -177,8 +153,6 @@ class CreateIndexAction(BaseAction):
         content: The content including the navigation table.
     """
 
-    type_: typing.Literal[ActionType.CREATE]
-
     title: NavlinkTitle
     content: Content
 
@@ -194,8 +168,6 @@ class NoopAction(BaseAction):
         content: The documentation content of the page.
     """
 
-    type_: typing.Literal[ActionType.NOOP]
-
     level: Level
     path: TablePath
     navlink: Navlink
@@ -210,8 +182,6 @@ class NoopIndexAction(BaseAction):
         content: The content including the navigation table.
         url: The URL to the index page.
     """
-
-    type_: typing.Literal[ActionType.NOOP]
 
     content: Content
     url: Url
@@ -264,8 +234,6 @@ class UpdateAction(BaseAction):
         content_change: The change to the documentation content.
     """
 
-    type_: typing.Literal[ActionType.UPDATE]
-
     level: Level
     path: TablePath
     navlink_change: NavlinkChange
@@ -281,8 +249,6 @@ class UpdateIndexAction(BaseAction):
         url: The URL to the index page.
     """
 
-    type_: typing.Literal[ActionType.UPDATE]
-
     content_change: IndexContentChange
     url: Url
 
@@ -297,8 +263,6 @@ class DeleteAction(BaseAction):
         navlink: The link to the page
         content: The documentation content.
     """
-
-    type_: typing.Literal[ActionType.DELETE]
 
     level: Level
     path: TablePath

--- a/tests/integration/test___init__.py
+++ b/tests/integration/test___init__.py
@@ -87,7 +87,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     assert tuple(urls_with_actions) == (index_url,)
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert index_topic == f"{reconcile.NAVIGATION_TABLE_START}".strip()
-    assert_substrings_in_string((index_url, "'update'", "'skip'"), caplog.text)
+    assert_substrings_in_string((index_url, "Update", "'skip'"), caplog.text)
 
     # 3. docs with an index file
     caplog.clear()
@@ -99,7 +99,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     assert tuple(urls_with_actions) == (index_url,)
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert index_topic == f"{index_content}{reconcile.NAVIGATION_TABLE_START}"
-    assert_substrings_in_string((index_url, "'update'", "'success'"), caplog.text)
+    assert_substrings_in_string((index_url, "Update", "'success'"), caplog.text)
 
     # 4. docs with a documentation file added in dry run mode
     caplog.clear()
@@ -111,7 +111,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     )
 
     assert tuple(urls_with_actions) == (index_url,)
-    assert_substrings_in_string(("'create'", "'skip'"), caplog.text)
+    assert_substrings_in_string(("Create", "'skip'"), caplog.text)
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_content_1 not in index_topic
 
@@ -127,7 +127,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
     doc_table_line_1 = f"| 1 | {doc_table_key} | [{doc_content_1}]({urlparse(doc_url).path}) |"
     assert_substrings_in_string(
-        chain(urls, (doc_table_line_1, "'create'", "'update'", "'success'")), caplog.text
+        chain(urls, (doc_table_line_1, "Create", "Update", "'success'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_table_line_1 in index_topic
@@ -143,7 +143,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     )
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
-    assert_substrings_in_string(chain(urls, (doc_table_line_1, "'update'", "'skip'")), caplog.text)
+    assert_substrings_in_string(chain(urls, (doc_table_line_1, "Update", "'skip'")), caplog.text)
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_table_line_1 in index_topic
     doc_topic = discourse_api.retrieve_topic(url=doc_url)
@@ -159,7 +159,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
     doc_table_line_2 = f"| 1 | {doc_table_key} | [{doc_content_2}]({urlparse(doc_url).path}) |"
     assert_substrings_in_string(
-        chain(urls, (doc_table_line_1, doc_table_line_2, "'update'", "'success'")), caplog.text
+        chain(urls, (doc_table_line_1, doc_table_line_2, "Update", "'success'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_table_line_2 in index_topic
@@ -178,7 +178,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
     nested_dir_table_line = f"| 1 | {nested_dir_table_key} | [Nested Dir]() |"
     assert_substrings_in_string(
-        chain(urls, (nested_dir_table_line, "'create'", "'success'")), caplog.text
+        chain(urls, (nested_dir_table_line, "Create", "'success'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert nested_dir_table_line in index_topic
@@ -202,7 +202,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
         f" [{nested_dir_doc_content}]({urlparse(nested_dir_doc_url).path}) |"
     )
     assert_substrings_in_string(
-        chain(urls, (nested_dir_doc_table_line, "'create'", "'success'")), caplog.text
+        chain(urls, (nested_dir_doc_table_line, "Create", "'success'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert nested_dir_doc_table_line in index_topic
@@ -219,7 +219,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, nested_dir_doc_url, index_url)
     assert_substrings_in_string(
-        chain(urls, (nested_dir_doc_table_line, "'delete'", "'update'", "'skip'")), caplog.text
+        chain(urls, (nested_dir_doc_table_line, "Delete", "Update", "'skip'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert nested_dir_doc_table_line in index_topic
@@ -236,7 +236,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, nested_dir_doc_url, index_url)
     assert_substrings_in_string(
-        chain(urls, (nested_dir_doc_table_line, "'delete'", "'update'", "'skip'")), caplog.text
+        chain(urls, (nested_dir_doc_table_line, "Delete", "Update", "'skip'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert nested_dir_doc_table_line not in index_topic
@@ -253,7 +253,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
     assert_substrings_in_string(
-        chain(urls, (nested_dir_table_line, "'delete'", "'update'", "'success'")), caplog.text
+        chain(urls, (nested_dir_table_line, "Delete", "Update", "'success'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert nested_dir_table_line not in index_topic
@@ -268,7 +268,7 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
     assert_substrings_in_string(
-        chain(urls, (doc_table_line_2, "'delete'", "'update'", "'success'")), caplog.text
+        chain(urls, (doc_table_line_2, "Delete", "Update", "'success'")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_table_line_2 not in index_topic
@@ -284,6 +284,6 @@ async def test_run(discourse_api: Discourse, tmp_path: Path, caplog: pytest.LogC
     )
 
     assert (urls := tuple(urls_with_actions)) == (index_url,)
-    assert_substrings_in_string(chain(urls, ("'update'", "'success'")), caplog.text)
+    assert_substrings_in_string(chain(urls, ("Update", "'success'")), caplog.text)
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert index_content not in index_topic

--- a/tests/unit/test_action.py
+++ b/tests/unit/test_action.py
@@ -32,7 +32,6 @@ def test__create_directory(dry_run: bool, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.INFO)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     create_action = src_types.CreateAction(
-        type_=src_types.ActionType.CREATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_title=(navlink_title := "title 1"),
@@ -69,7 +68,6 @@ def test__create_file_dry_run(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.INFO)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     create_action = src_types.CreateAction(
-        type_=src_types.ActionType.CREATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_title=(navlink_title := "title 1"),
@@ -103,7 +101,6 @@ def test__create_file_fail(caplog: pytest.LogCaptureFixture):
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.create_topic.side_effect = (error := exceptions.DiscourseError("failed"))
     create_action = src_types.CreateAction(
-        type_=src_types.ActionType.CREATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_title=(navlink_title := "title 1"),
@@ -139,7 +136,6 @@ def test__create_file(caplog: pytest.LogCaptureFixture):
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.create_topic.return_value = (url := "url 1")
     create_action = src_types.CreateAction(
-        type_=src_types.ActionType.CREATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_title=(navlink_title := "title 1"),
@@ -172,7 +168,6 @@ def test__create_file(caplog: pytest.LogCaptureFixture):
     [
         pytest.param(
             src_types.NoopAction(
-                type_=src_types.ActionType.NOOP,
                 level=(level := 1),
                 path=(path := "path 1"),
                 navlink=(navlink := src_types.Navlink(title="title 1", link=None)),
@@ -183,7 +178,6 @@ def test__create_file(caplog: pytest.LogCaptureFixture):
         ),
         pytest.param(
             src_types.NoopAction(
-                type_=src_types.ActionType.NOOP,
                 level=(level := 1),
                 path=(path := "path 1"),
                 navlink=(navlink := src_types.Navlink(title="title 1", link="link 1")),
@@ -237,7 +231,6 @@ def test__update_directory(dry_run: bool, caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.INFO)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     update_action = src_types.UpdateAction(
-        type_=src_types.ActionType.UPDATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_change=src_types.NavlinkChange(
@@ -278,7 +271,6 @@ def test__update_file_dry_run(caplog: pytest.LogCaptureFixture):
     url = "url 1"
     mocked_discourse.absolute_url.return_value = url
     update_action = src_types.UpdateAction(
-        type_=src_types.ActionType.UPDATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_change=src_types.NavlinkChange(
@@ -316,7 +308,6 @@ def test__update_file_navlink_title_change(caplog: pytest.LogCaptureFixture):
     url = "url 1"
     mocked_discourse.absolute_url.return_value = url
     update_action = src_types.UpdateAction(
-        type_=src_types.ActionType.UPDATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_change=src_types.NavlinkChange(
@@ -355,7 +346,6 @@ def test__update_file_navlink_content_change_discourse_error(caplog: pytest.LogC
     mocked_discourse.absolute_url.return_value = url
     mocked_discourse.update_topic.side_effect = (error := exceptions.DiscourseError("failed"))
     update_action = src_types.UpdateAction(
-        type_=src_types.ActionType.UPDATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_change=src_types.NavlinkChange(
@@ -395,7 +385,6 @@ def test__update_file_navlink_content_change(caplog: pytest.LogCaptureFixture):
     url = "url 1"
     mocked_discourse.absolute_url.return_value = url
     update_action = src_types.UpdateAction(
-        type_=src_types.ActionType.UPDATE,
         level=(level := 1),
         path=(path := "path 1"),
         navlink_change=src_types.NavlinkChange(
@@ -439,7 +428,6 @@ def test__update_file_navlink_content_change_error(content_change: src_types.Con
     """
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     update_action = src_types.UpdateAction(
-        type_=src_types.ActionType.UPDATE,
         level=1,
         path="path 1",
         navlink_change=src_types.NavlinkChange(
@@ -495,7 +483,6 @@ def test__delete_not_delete(
     url = "url 1"
     mocked_discourse.absolute_url.return_value = url
     delete_action = src_types.DeleteAction(
-        type_=src_types.ActionType.DELETE,
         level=1,
         path="path 1",
         navlink=src_types.Navlink(title="title 1", link=navlink_link),
@@ -531,7 +518,6 @@ def test__delete_error(caplog: pytest.LogCaptureFixture):
     mocked_discourse.absolute_url.return_value = url
     mocked_discourse.delete_topic.side_effect = (error := exceptions.DiscourseError("fail"))
     delete_action = src_types.DeleteAction(
-        type_=src_types.ActionType.DELETE,
         level=1,
         path="path 1",
         navlink=src_types.Navlink(title="title 1", link=(link := "link 1")),
@@ -566,7 +552,6 @@ def test__delete(caplog: pytest.LogCaptureFixture):
     url = "url 1"
     mocked_discourse.absolute_url.return_value = url
     delete_action = src_types.DeleteAction(
-        type_=src_types.ActionType.DELETE,
         level=1,
         path="path 1",
         navlink=src_types.Navlink(title="title 1", link=(link := "link 1")),
@@ -595,7 +580,6 @@ def test__delete(caplog: pytest.LogCaptureFixture):
     [
         pytest.param(
             src_types.CreateAction(
-                type_=src_types.ActionType.CREATE,
                 level=1,
                 path="path 1",
                 navlink_title="title 1",
@@ -606,7 +590,6 @@ def test__delete(caplog: pytest.LogCaptureFixture):
         ),
         pytest.param(
             src_types.NoopAction(
-                type_=src_types.ActionType.NOOP,
                 level=1,
                 path="path 1",
                 navlink=src_types.Navlink(title="title 1", link=None),
@@ -617,7 +600,6 @@ def test__delete(caplog: pytest.LogCaptureFixture):
         ),
         pytest.param(
             src_types.UpdateAction(
-                type_=src_types.ActionType.UPDATE,
                 level=1,
                 path="path 1",
                 navlink_change=src_types.NavlinkChange(
@@ -631,7 +613,6 @@ def test__delete(caplog: pytest.LogCaptureFixture):
         ),
         pytest.param(
             src_types.DeleteAction(
-                type_=src_types.ActionType.DELETE,
                 level=1,
                 path="path 1",
                 navlink=src_types.Navlink(title="title 1", link=None),
@@ -671,22 +652,17 @@ def test__run_one(
     "index_action, expected_url",
     [
         pytest.param(
-            src_types.CreateIndexAction(
-                type_=src_types.ActionType.CREATE, title="title 1", content="content 1"
-            ),
+            src_types.CreateIndexAction(title="title 1", content="content 1"),
             action.DRY_RUN_NAVLINK_LINK,
             id="create",
         ),
         pytest.param(
-            src_types.NoopIndexAction(
-                type_=src_types.ActionType.NOOP, url=(url := "url 1"), content="content 1"
-            ),
+            src_types.NoopIndexAction(url=(url := "url 1"), content="content 1"),
             url,
             id="noop",
         ),
         pytest.param(
             src_types.UpdateIndexAction(
-                type_=src_types.ActionType.UPDATE,
                 url=(url := "url 1"),
                 content_change=src_types.IndexContentChange(old="content 1", new="content 2"),
             ),
@@ -733,7 +709,6 @@ def test__run_index_create_error(caplog: pytest.LogCaptureFixture):
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.create_topic.side_effect = (error := exceptions.DiscourseError("failed"))
     index_action = src_types.CreateIndexAction(
-        type_=src_types.ActionType.CREATE,
         title=(title := "title 1"),
         content=(content := "content 1"),
     )
@@ -762,7 +737,6 @@ def test__run_index_create(caplog: pytest.LogCaptureFixture):
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.create_topic.return_value = (url := "url 1")
     index_action = src_types.CreateIndexAction(
-        type_=src_types.ActionType.CREATE,
         title=(title := "title 1"),
         content=(content := "content 1"),
     )
@@ -790,9 +764,7 @@ def test__run_index_noop(caplog: pytest.LogCaptureFixture):
     """
     caplog.set_level(logging.INFO)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
-    index_action = src_types.NoopIndexAction(
-        type_=src_types.ActionType.NOOP, url=(url := "url 1"), content="content 1"
-    )
+    index_action = src_types.NoopIndexAction(url=(url := "url 1"), content="content 1")
 
     returned_report = action._run_index(
         action=index_action, discourse=mocked_discourse, dry_run=False
@@ -819,7 +791,6 @@ def test__run_index_update_error(caplog: pytest.LogCaptureFixture):
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     mocked_discourse.update_topic.side_effect = (error := exceptions.DiscourseError("failed"))
     index_action = src_types.UpdateIndexAction(
-        type_=src_types.ActionType.UPDATE,
         url=(url := "url 1"),
         content_change=src_types.IndexContentChange(old="content 1", new=(content := "content 2")),
     )
@@ -847,7 +818,6 @@ def test__run_index_update(caplog: pytest.LogCaptureFixture):
     caplog.set_level(logging.INFO)
     mocked_discourse = mock.MagicMock(spec=discourse.Discourse)
     index_action = src_types.UpdateIndexAction(
-        type_=src_types.ActionType.UPDATE,
         url=(url := "url 1"),
         content_change=src_types.IndexContentChange(old="content 1", new=(content := "content 2")),
     )
@@ -875,7 +845,6 @@ def test__run_index_update(caplog: pytest.LogCaptureFixture):
         pytest.param(
             (
                 src_types.NoopAction(
-                    type_=src_types.ActionType.NOOP,
                     level=(level := 1),
                     path=(path := "path 1"),
                     navlink=(
@@ -897,7 +866,6 @@ def test__run_index_update(caplog: pytest.LogCaptureFixture):
         pytest.param(
             (
                 src_types.NoopAction(
-                    type_=src_types.ActionType.NOOP,
                     level=(level_1 := 1),
                     path=(path_1 := "path 1"),
                     navlink=(
@@ -906,7 +874,6 @@ def test__run_index_update(caplog: pytest.LogCaptureFixture):
                     content="content 1",
                 ),
                 src_types.NoopAction(
-                    type_=src_types.ActionType.NOOP,
                     level=(level_2 := 2),
                     path=(path_2 := "path 2"),
                     navlink=(

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -28,7 +28,7 @@ def test__local_only_file(tmp_path: Path):
 
     returned_action = reconcile._local_only(path_info=path_info)
 
-    assert returned_action.type_ == types_.ActionType.CREATE
+    assert isinstance(returned_action, types_.CreateAction)
     assert returned_action.level == path_info.level
     assert returned_action.path == path_info.table_path
     assert returned_action.navlink_title == path_info.navlink_title
@@ -48,7 +48,7 @@ def test__local_only_directory(tmp_path: Path):
 
     returned_action = reconcile._local_only(path_info=path_info)
 
-    assert returned_action.type_ == types_.ActionType.CREATE
+    assert isinstance(returned_action, types_.CreateAction)
     assert returned_action.level == path_info.level
     assert returned_action.path == path_info.table_path
     assert returned_action.navlink_title == path_info.navlink_title
@@ -128,7 +128,7 @@ def test__local_and_server_file_same(local_content: str, server_content: str, tm
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == types_.ActionType.NOOP
+    assert isinstance(returned_action, types_.NoopAction)
     assert returned_action.level == level
     assert returned_action.path == table_path
     # mypy has difficulty with determining which action is returned
@@ -161,7 +161,7 @@ def test__local_and_server_file_content_change(tmp_path: Path):
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == types_.ActionType.UPDATE
+    assert isinstance(returned_action, types_.UpdateAction)
     assert returned_action.level == level
     assert returned_action.path == table_path
     # mypy has difficulty with determining which action is returned
@@ -196,7 +196,7 @@ def test__local_and_server_file_navlink_title_change(tmp_path: Path):
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == types_.ActionType.UPDATE
+    assert isinstance(returned_action, types_.UpdateAction)
     assert returned_action.level == level
     assert returned_action.path == table_path
     # mypy has difficulty with determining which action is returned
@@ -230,7 +230,7 @@ def test__local_and_server_directory_same(tmp_path: Path):
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == types_.ActionType.NOOP
+    assert isinstance(returned_action, types_.NoopAction)
     assert returned_action.level == level
     assert returned_action.path == table_path
     # mypy has difficulty with determining which action is returned
@@ -260,7 +260,7 @@ def test__local_and_server_directory_navlink_title_changed(tmp_path: Path):
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == types_.ActionType.UPDATE
+    assert isinstance(returned_action, types_.UpdateAction)
     assert returned_action.level == level
     assert returned_action.path == table_path
     # mypy has difficulty with determining which action is returned
@@ -294,7 +294,7 @@ def test__local_and_server_directory_to_file(tmp_path: Path):
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == types_.ActionType.CREATE
+    assert isinstance(returned_action, types_.CreateAction)
     assert returned_action.level == level
     assert returned_action.path == table_path
     # mypy has difficulty with determining which action is returned
@@ -326,13 +326,13 @@ def test__local_and_server_file_to_directory(tmp_path: Path):
     )
 
     assert len(returned_actions) == 2
-    assert returned_actions[0].type_ == types_.ActionType.DELETE
+    assert isinstance(returned_actions[0], types_.DeleteAction)
     assert returned_actions[0].level == level
     assert returned_actions[0].path == table_path
     # mypy has difficulty with determining which action is returned
     assert returned_actions[0].navlink == navlink  # type: ignore
     assert returned_actions[0].content == content  # type: ignore
-    assert returned_actions[1].type_ == types_.ActionType.CREATE
+    assert isinstance(returned_actions[1], types_.CreateAction)
     assert returned_actions[1].level == level
     assert returned_actions[1].path == table_path
     # mypy has difficulty with determining which action is returned
@@ -354,7 +354,7 @@ def test__server_only_file():
 
     returned_action = reconcile._server_only(table_row=table_row, discourse=mock_discourse)
 
-    assert returned_action.type_ == types_.ActionType.DELETE
+    assert isinstance(returned_action, types_.DeleteAction)
     assert returned_action.level == table_row.level
     assert returned_action.path == table_row.path
     assert returned_action.navlink == table_row.navlink
@@ -374,7 +374,7 @@ def test__server_only_directory():
 
     returned_action = reconcile._server_only(table_row=table_row, discourse=mock_discourse)
 
-    assert returned_action.type_ == types_.ActionType.DELETE
+    assert isinstance(returned_action, types_.DeleteAction)
     assert returned_action.level == table_row.level
     assert returned_action.path == table_row.path
     assert returned_action.navlink == table_row.navlink
@@ -411,14 +411,14 @@ def path_info_mkdir(path_info: types_.PathInfo, base_dir: Path) -> types_.PathIn
 # Pylint diesn't understand how the walrus operator works
 # pylint: disable=undefined-variable,unused-variable
 @pytest.mark.parametrize(
-    "path_info, table_row, expected_action",
+    "path_info, table_row, expected_action_type",
     [
         pytest.param(
             types_.PathInfo(
                 local_path=Path("dir1"), level=1, table_path="path 1", navlink_title="title 1"
             ),
             None,
-            types_.ActionType.CREATE,
+            types_.CreateAction,
             id="path info defined table row None",
         ),
         pytest.param(
@@ -429,7 +429,7 @@ def path_info_mkdir(path_info: types_.PathInfo, base_dir: Path) -> types_.PathIn
                 navlink_title=(title := "title 1"),
             ),
             types_.TableRow(level=1, path=path, navlink=types_.Navlink(title=title, link=None)),
-            types_.ActionType.NOOP,
+            types_.NoopAction,
             id="path info defined table row defined",
         ),
         pytest.param(
@@ -437,7 +437,7 @@ def path_info_mkdir(path_info: types_.PathInfo, base_dir: Path) -> types_.PathIn
             types_.TableRow(
                 level=1, path="path 1", navlink=types_.Navlink(title="title 1", link=None)
             ),
-            types_.ActionType.DELETE,
+            types_.DeleteAction,
             id="path info None table row defined",
         ),
     ],
@@ -446,13 +446,13 @@ def path_info_mkdir(path_info: types_.PathInfo, base_dir: Path) -> types_.PathIn
 def test__calculate_action(
     path_info: types_.PathInfo | None,
     table_row: types_.TableRow | None,
-    expected_action: types_.ActionType,
+    expected_action_type: type[types_.AnyAction],
     tmp_path: Path,
 ):
     """
     arrange: given path info and table row for a directory and grouping
     act: when _calculate_action is called with the path info and table row
-    assert: then the expected action is returned.
+    assert: then the expected action type is returned.
     """
     mock_discourse = mock.MagicMock(spec=discourse.Discourse)
     if path_info is not None:
@@ -462,13 +462,13 @@ def test__calculate_action(
         path_info=path_info, table_row=table_row, discourse=mock_discourse
     )
 
-    assert returned_action.type_ == expected_action
+    assert isinstance(returned_action, expected_action_type)
 
 
 # Pylint diesn't understand how the walrus operator works
 # pylint: disable=undefined-variable,unused-variable
 @pytest.mark.parametrize(
-    "path_infos, table_rows, expected_actions",
+    "path_infos, table_rows, expected_action_types",
     [
         pytest.param((), (), (), id="empty path infos empty table rows"),
         pytest.param(
@@ -478,7 +478,7 @@ def test__calculate_action(
                 ),
             ),
             (),
-            (types_.ActionType.CREATE,),
+            (types_.CreateAction,),
             id="single path info empty table rows",
         ),
         pytest.param(
@@ -491,7 +491,7 @@ def test__calculate_action(
                 ),
             ),
             (),
-            (types_.ActionType.CREATE, types_.ActionType.CREATE),
+            (types_.CreateAction, types_.CreateAction),
             id="multiple path infos empty table rows",
         ),
         pytest.param(
@@ -501,7 +501,7 @@ def test__calculate_action(
                     level=1, path="path 1", navlink=types_.Navlink(title="title 1", link=None)
                 ),
             ),
-            (types_.ActionType.DELETE,),
+            (types_.DeleteAction,),
             id="empty path infos single table row",
         ),
         pytest.param(
@@ -514,7 +514,7 @@ def test__calculate_action(
                     level=2, path="path 2", navlink=types_.Navlink(title="title 2", link=None)
                 ),
             ),
-            (types_.ActionType.DELETE, types_.ActionType.DELETE),
+            (types_.DeleteAction, types_.DeleteAction),
             id="empty path infos multiple table rows",
         ),
         pytest.param(
@@ -531,7 +531,7 @@ def test__calculate_action(
                     level=level, path=path, navlink=types_.Navlink(title=title, link=None)
                 ),
             ),
-            (types_.ActionType.NOOP,),
+            (types_.NoopAction,),
             id="single path info single table row match",
         ),
         pytest.param(
@@ -544,7 +544,7 @@ def test__calculate_action(
                 ),
             ),
             (types_.TableRow(level=2, path=path, navlink=types_.Navlink(title=title, link=None)),),
-            (types_.ActionType.CREATE, types_.ActionType.DELETE),
+            (types_.CreateAction, types_.DeleteAction),
             id="single path info single table row level mismatch",
         ),
         pytest.param(
@@ -561,7 +561,7 @@ def test__calculate_action(
                     level=level, path="path 2", navlink=types_.Navlink(title=title, link=None)
                 ),
             ),
-            (types_.ActionType.CREATE, types_.ActionType.DELETE),
+            (types_.CreateAction, types_.DeleteAction),
             id="single path info single table row path mismatch",
         ),
     ],
@@ -570,7 +570,7 @@ def test__calculate_action(
 def test_run(
     path_infos: tuple[types_.PathInfo, ...],
     table_rows: tuple[types_.TableRow, ...],
-    expected_actions: tuple[types_.ActionType, ...],
+    expected_action_types: tuple[type[types_.AnyAction], ...],
     tmp_path: Path,
 ):
     """
@@ -585,7 +585,10 @@ def test_run(
         path_infos=path_infos, table_rows=table_rows, discourse=mock_discourse
     )
 
-    assert tuple(returned_action.type_ for returned_action in returned_actions) == expected_actions
+    assert (
+        tuple(type(returned_action) for returned_action in returned_actions)
+        == expected_action_types
+    )
 
 
 # Pylint diesn't understand how the walrus operator works
@@ -601,9 +604,7 @@ def test_run(
             ),
             (),
             types_.CreateIndexAction(
-                type_=types_.ActionType.CREATE,
-                title=local_title,
-                content=f"{reconcile.NAVIGATION_TABLE_START.strip()}",
+                title=local_title, content=f"{reconcile.NAVIGATION_TABLE_START.strip()}"
             ),
             id="empty local only empty rows",
         ),
@@ -617,9 +618,7 @@ def test_run(
             ),
             (),
             types_.CreateIndexAction(
-                type_=types_.ActionType.CREATE,
-                title=local_title,
-                content=f"{local_content}{reconcile.NAVIGATION_TABLE_START}",
+                title=local_title, content=f"{local_content}{reconcile.NAVIGATION_TABLE_START}"
             ),
             id="local only empty rows",
         ),
@@ -639,7 +638,6 @@ def test_run(
                 ),
             ),
             types_.CreateIndexAction(
-                type_=types_.ActionType.CREATE,
                 title=local_title,
                 content=(
                     f"{local_content}{reconcile.NAVIGATION_TABLE_START}\n"
@@ -669,7 +667,6 @@ def test_run(
                 ),
             ),
             types_.CreateIndexAction(
-                type_=types_.ActionType.CREATE,
                 title=local_title,
                 content=(
                     f"{local_content}{reconcile.NAVIGATION_TABLE_START}\n"
@@ -690,11 +687,7 @@ def test_run(
                 name="name 1",
             ),
             (),
-            types_.NoopIndexAction(
-                type_=types_.ActionType.NOOP,
-                content=server_content,
-                url=url,
-            ),
+            types_.NoopIndexAction(content=server_content, url=url),
             id="local server same empty rows",
         ),
         pytest.param(
@@ -709,11 +702,7 @@ def test_run(
                 name="name 1",
             ),
             (),
-            types_.NoopIndexAction(
-                type_=types_.ActionType.NOOP,
-                content=server_content[1:],
-                url=url,
-            ),
+            types_.NoopIndexAction(content=server_content[1:], url=url),
             id="local server whitespace different same empty rows",
         ),
         pytest.param(
@@ -729,11 +718,7 @@ def test_run(
                 name="name 1",
             ),
             (),
-            types_.NoopIndexAction(
-                type_=types_.ActionType.NOOP,
-                content=server_content,
-                url=url,
-            ),
+            types_.NoopIndexAction(content=server_content, url=url),
             id="local whitespace server different same empty rows",
         ),
         pytest.param(
@@ -744,7 +729,6 @@ def test_run(
             ),
             (),
             types_.UpdateIndexAction(
-                type_=types_.ActionType.UPDATE,
                 content_change=types_.IndexContentChange(
                     old=server_content,
                     new=f"{local_content}{reconcile.NAVIGATION_TABLE_START}",


### PR DESCRIPTION
Changes the match statements to be based on the `type` function rather than the `type_` attribute, closes #16 