### PR TITLE
change topics to be created unlisted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Toppics are now created unlisted on discourse
+
 ## [v0.1.1] - 2022-12-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Toppics are now created unlisted on discourse
+- Topics are now created unlisted on discourse
 
 ## [v0.1.1] - 2022-12-13
 

--- a/src/discourse.py
+++ b/src/discourse.py
@@ -354,7 +354,11 @@ class Discourse:
         """
         try:
             post = self._client.create_post(
-                title=title, category_id=self._category_id, tags=self.tags, content=content
+                title=title,
+                category_id=self._category_id,
+                tags=self.tags,
+                content=content,
+                unlist_topic=True,
             )
         except pydiscourse.exceptions.DiscourseError as discourse_error:
             raise DiscourseError(

--- a/tests/integration/test_discourse.py
+++ b/tests/integration/test_discourse.py
@@ -57,6 +57,7 @@ async def test_create_retrieve_update_delete_topic(
     assert (
         topic["category_id"] == discourse_category_id
     ), "post was not created with the correct category id"
+    assert topic["visible"] is False, "topic is listed"
 
     # Check permissions
     assert discourse_api.check_topic_read_permission(


### PR DESCRIPTION
This is because the documentation topics on discourse should not be listed in search results or on the new topics feed.