### PR TITLE
remove unnecessary input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v0.5.0] - 2023-04-13
+
+### Changed
+
+- Removed `base_branch` input.
+
 ## [v0.4.0] - 2023-04-13
 
 ### Changed

--- a/action.yaml
+++ b/action.yaml
@@ -47,11 +47,6 @@ inputs:
     required: false
     type: string
     default: "upload-charm-docs/base-content"
-  base_branch:
-    description: |
-      DEPRECATED - here for backwards compatibility. This input is no longer used.
-    required: false
-    type: string
 outputs:
   urls_with_actions:
     description: |


### PR DESCRIPTION
Removes the deprecated `base-branch` input now that `operator-workflows` has been updated to no longer use it