### PR TITLE
handle git commit tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Add support for handling tags that are directly linked to a commit which
+  resulted in a failure before.
+
 ## [v0.4.0] - 2023-04-13
 
 ### Changed

--- a/src/repository.py
+++ b/src/repository.py
@@ -195,8 +195,12 @@ class Client:
         try:
             # Need both steps, the ref allows for retrieval by tag name
             tag_ref = self._github_repo.get_git_ref(f"tags/{tag_name}")
-            # The ref does not contain the commit SHA, need to retrieve the tag object
-            git_tag = self._github_repo.get_git_tag(tag_ref.object.sha)
+            if tag_ref.object.type == "commit":
+                commit_sha = tag_ref.object.sha
+            else:
+                # The ref does not contain the commit SHA, need to retrieve the tag object
+                git_tag = self._github_repo.get_git_tag(tag_ref.object.sha)
+                commit_sha = git_tag.object.sha
         except UnknownObjectException as exc:
             raise RepositoryTagNotFoundError(
                 f"Could not retrieve the tag {tag_name=}. {exc=!r}"
@@ -206,7 +210,7 @@ class Client:
 
         # Get the file contents
         try:
-            content_file = self._github_repo.get_contents(path, git_tag.object.sha)
+            content_file = self._github_repo.get_contents(path, commit_sha)
         except UnknownObjectException as exc:
             raise RepositoryFileNotFoundError(
                 f"Could not retrieve the file at {path=} for tag {tag_name}. {exc=!r}"

--- a/src/repository.py
+++ b/src/repository.py
@@ -193,12 +193,14 @@ class Client:
         """
         # Get the tag
         try:
-            # Need both steps, the ref allows for retrieval by tag name
             tag_ref = self._github_repo.get_git_ref(f"tags/{tag_name}")
+            # git has 2 types of tags, lightweight and annotated tags:
+            # https://git-scm.com/book/en/v2/Git-Basics-Tagging
             if tag_ref.object.type == "commit":
+                # lightweight tag, the SHA of the tag is the commit SHA
                 commit_sha = tag_ref.object.sha
             else:
-                # The ref does not contain the commit SHA, need to retrieve the tag object
+                # annotated tag, need to retrieve the commit SHA linked to the tag
                 git_tag = self._github_repo.get_git_tag(tag_ref.object.sha)
                 commit_sha = git_tag.object.sha
         except UnknownObjectException as exc:


### PR DESCRIPTION
This PR adds support for retrieving content from a tag that is directly attached to a git commit. It would be good to change the `e2e` tests as well, I propose this to be done in a follow up PR as I think using `git` by default creates direct tags rather than indirect tags