### PR TITLE
change logic to not consider update actions where local and server is the same

### DIFF
--- a/src/check.py
+++ b/src/check.py
@@ -51,14 +51,22 @@ def get_path_with_diffs(actions: Iterable[UpdateAction]) -> PathsWithDiff:
     Returns:
         The paths that have differences.
     """
-    # Need an iterator for both attributes
-    base_local_actions, base_server_actions = tee(
+    # Filter any actions without a change in content or None base
+    actions_with_changes = (
         action
         for action in actions
         if action.content_change is not None and action.content_change.base is not None
     )
+    # Remove an actions where local and server are the same
     # The access to optional attributes is safe because of the filter above, mypy doesn't track
     # to this degree
+    local_server_diff_actions = (
+        action
+        for action in actions_with_changes
+        if action.content_change.local != action.content_change.server  # type: ignore
+    )
+    # Need an iterator for both attributes
+    base_local_actions, base_server_actions = tee(local_server_diff_actions)
     return PathsWithDiff(
         base_local_diffs=tuple(
             format_path(action.path)

--- a/tests/unit/test_check.py
+++ b/tests/unit/test_check.py
@@ -68,6 +68,19 @@ def _track_paths_with_diff_parameters():
             (
                 factories.UpdateActionFactory(
                     content_change=factories.ContentChangeFactory(
+                        base="base 1", local=(local_1 := "local 1"), server=local_1
+                    ),
+                    path=(path_1 := ("path 1",)),
+                ),
+            ),
+            (),
+            (),
+            id="single base diff server local same",
+        ),
+        pytest.param(
+            (
+                factories.UpdateActionFactory(
+                    content_change=factories.ContentChangeFactory(
                         base="base 1", local="local 1", server="server 1"
                     ),
                     path=(path_1 := ("path 1",)),
@@ -108,6 +121,23 @@ def _track_paths_with_diff_parameters():
             (check.format_path(path_1), check.format_path(path_2)),
             (check.format_path(path_1), check.format_path(path_2)),
             id="multiple all diff",
+        ),
+        pytest.param(
+            (
+                factories.UpdateActionFactory(
+                    content_change=factories.ContentChangeFactory(
+                        base="base 1", local=(local_1 := "local 1"), server=local_1
+                    )
+                ),
+                factories.UpdateActionFactory(
+                    content_change=factories.ContentChangeFactory(
+                        base="base 2", local=(local_2 := "local 2"), server=local_2
+                    )
+                ),
+            ),
+            (),
+            (),
+            id="multiple base diff local server same",
         ),
     ]
 
@@ -294,7 +324,7 @@ def _test_conflicts_parameters():
         pytest.param(
             (
                 action_1 := factories.UpdateActionFactory(
-                    content_change=types_.ContentChange(base="a", server="b", local="b")
+                    content_change=types_.ContentChange(base="a", server="b", local="a")
                 ),
                 action_2 := factories.UpdateActionFactory(
                     content_change=types_.ContentChange(base="x", server="x", local="y")
@@ -303,7 +333,7 @@ def _test_conflicts_parameters():
             False,
             (
                 ExpectedProblem(
-                    path="/".join(action_1.path),
+                    path="/".join(action_2.path),
                     description_contents=(
                         "detected",
                         "unmerged",
@@ -322,7 +352,7 @@ def _test_conflicts_parameters():
         pytest.param(
             (
                 action_1 := factories.UpdateActionFactory(
-                    content_change=types_.ContentChange(base="a", server="b", local="b")
+                    content_change=types_.ContentChange(base="a", server="b", local="a")
                 ),
                 action_2 := factories.UpdateActionFactory(
                     content_change=types_.ContentChange(base="x", server="x", local="y")


### PR DESCRIPTION
Changes the conflict detection logic to ignore update actions where the local (on the PR) and server (on discourse) content is the same for the purpose of logical conflict detection