### PR TITLE
Close open PR if Discourse and Github content match

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -131,6 +131,8 @@ def run_migrate(clients: Clients, user_inputs: UserInputs) -> dict[str, str]:
             main_hash = repo.current_commit
         clients.repository.tag_commit(DOCUMENTATION_TAG, main_hash)
 
+    pull_request = clients.repository.get_pull_request(DEFAULT_BRANCH_NAME)
+
     # Check difference with main
     changes = recreate_docs(clients, DOCUMENTATION_TAG)
     if not changes:
@@ -139,15 +141,18 @@ def run_migrate(clients: Clients, user_inputs: UserInputs) -> dict[str, str]:
             user_inputs.commit_sha,
             DOCUMENTATION_TAG,
         )
+        # If a PR is open we should probably close the PR
+        if pull_request is not None:
+            pull_request.edit(state="closed")
         return {}
 
-    pr_link = clients.repository.get_pull_request(DEFAULT_BRANCH_NAME)
-
-    if pr_link is not None:
-        logging.info("upload-charm-documents pull request already open at %s", pr_link)
+    if pull_request is not None:
+        logging.info(
+            "upload-charm-documents pull request already open at %s", pull_request.html_url
+        )
         clients.repository.update_pull_request(DEFAULT_BRANCH_NAME)
     else:
         logging.info("PR not existing: creating a new one...")
-        pr_link = clients.repository.create_pull_request(DOCUMENTATION_TAG)
+        pull_request = clients.repository.create_pull_request(DOCUMENTATION_TAG)
 
-    return {pr_link: ActionResult.SUCCESS}
+    return {pull_request.html_url: ActionResult.SUCCESS}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -141,7 +141,7 @@ def run_migrate(clients: Clients, user_inputs: UserInputs) -> dict[str, str]:
             user_inputs.commit_sha,
             DOCUMENTATION_TAG,
         )
-        # If a PR is open we should probably close the PR
+        # Given there are NO diffs compared to the base, if a PR is open, it should be closed
         if pull_request is not None:
             pull_request.edit(state="closed")
         return {}

--- a/tests/integration/test___init__run_migrate.py
+++ b/tests/integration/test___init__run_migrate.py
@@ -194,7 +194,12 @@ async def test_run_migrate(
 
     discourse_api.update_topic(content_page_2_url, content_page_2.content + " updated")
 
-    def mock_edit(*args, **kwargs):
+    def mock_edit(**kwargs):
+        """Mock edit method for the PullRequest object.
+
+        Args:
+            kwargs: keyword arguments
+        """
         assert kwargs["state"] == "closed"
 
     monkeypatch.setattr(PullRequest, "edit", mock_edit)

--- a/tests/integration/test___init__run_migrate.py
+++ b/tests/integration/test___init__run_migrate.py
@@ -194,10 +194,11 @@ async def test_run_migrate(
 
     discourse_api.update_topic(content_page_2_url, content_page_2.content + " updated")
 
-    def mock_edit(**kwargs):
+    def mock_edit(*args, **kwargs):  # pylint: disable=W0613
         """Mock edit method for the PullRequest object.
 
         Args:
+            args: positional arguments
             kwargs: keyword arguments
         """
         assert kwargs["state"] == "closed"

--- a/tests/integration/test___init__run_migrate.py
+++ b/tests/integration/test___init__run_migrate.py
@@ -39,6 +39,7 @@ async def test_run_migrate(
     upstream_repository_path: Path,
     mock_pull_request: PullRequest,
     mock_github_repo: MagicMock,
+    monkeypatch
 ):
     """
     arrange: given running discourse server
@@ -192,6 +193,12 @@ async def test_run_migrate(
     caplog.clear()
 
     discourse_api.update_topic(content_page_2_url, content_page_2.content + " updated")
+
+    def mock_edit(*args, **kwargs):
+        assert kwargs["state"] == "closed"
+        return
+
+    monkeypatch.setattr(PullRequest, "edit", mock_edit)
 
     urls_with_actions = run_migrate(
         Clients(

--- a/tests/integration/test___init__run_migrate.py
+++ b/tests/integration/test___init__run_migrate.py
@@ -39,7 +39,7 @@ async def test_run_migrate(
     upstream_repository_path: Path,
     mock_pull_request: PullRequest,
     mock_github_repo: MagicMock,
-    monkeypatch
+    monkeypatch,
 ):
     """
     arrange: given running discourse server
@@ -196,7 +196,6 @@ async def test_run_migrate(
 
     def mock_edit(*args, **kwargs):
         assert kwargs["state"] == "closed"
-        return
 
     monkeypatch.setattr(PullRequest, "edit", mock_edit)
 

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -743,8 +743,7 @@ def test_run_migrate_same_content_local_and_server(mock_edit_pull_request, caplo
 @mock.patch("src.repository.Client.get_pull_request")
 @mock.patch("github.PullRequest.PullRequest")
 def test_run_migrate_same_content_local_and_server_open_pr(
-    mocked_get_pull_request, mock_edit_pull_request,
-    caplog, mocked_clients, mock_pull_request
+    mocked_get_pull_request, mock_edit_pull_request, caplog, mocked_clients, mock_pull_request
 ):
     """
     arrange: given a path with a metadata.yaml that has docs key and docs directory aligned

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -737,7 +737,7 @@ def test_run_migrate_same_content_local_and_server(mock_edit_pull_request, caplo
     edit_call_args = [
         kwargs for name, args, kwargs in mock_edit_pull_request.mock_calls if name.endswith("edit")
     ]
-    assert len(edit_call_args) == 0
+    assert not edit_call_args
 
 
 @mock.patch("src.repository.Client.get_pull_request")

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -441,7 +441,7 @@ def test__run_migrate_with_pull_request(
     mocked_clients,
     upstream_git_repo: Repo,
     upstream_repository_path: Path,
-    mock_pull_request: PullRequest
+    mock_pull_request: PullRequest,
 ):
     """
     arrange: given metadata with name and docs and docs directory with updated content
@@ -790,5 +790,3 @@ def test_run_migrate_same_content_local_and_server_open_pr(
     assert not returned_migration_reports
     assert any("No community contribution found" in record.message for record in caplog.records)
     assert mock_edit_pull_request.called
-
-

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -435,13 +435,13 @@ def test__run_migrate(
     "src.repository.Client.metadata",
     types_.Metadata(name="name 1", docs="http://discourse/t/docs"),
 )
-@mock.patch("src.repository.Client.get_pull_request", return_value="test_url")
+@mock.patch("src.repository.Client.get_pull_request")
 def test__run_migrate_with_pull_request(
-    _,
+    mock_get_pull_request,
     mocked_clients,
     upstream_git_repo: Repo,
     upstream_repository_path: Path,
-    mock_pull_request: PullRequest,
+    mock_pull_request: PullRequest
 ):
     """
     arrange: given metadata with name and docs and docs directory with updated content
@@ -449,6 +449,8 @@ def test__run_migrate_with_pull_request(
     act: when _run_migrate is called
     assert: docs are migrated and the remote branch is updated.
     """
+    mock_get_pull_request.return_value = mock_pull_request
+
     index_content = """Content header.
 
     Content body.\n"""
@@ -494,9 +496,9 @@ def test__run_migrate_with_pull_request(
     "src.repository.Client.metadata",
     types_.Metadata(name="name 1", docs="http://discourse/t/docs"),
 )
-@mock.patch("src.repository.Client.get_pull_request", return_value="test_url")
+@mock.patch("src.repository.Client.get_pull_request")
 def test__run_migrate_with_pull_request_no_modification(
-    _,
+    mock_get_pull_request,
     mocked_clients,
     upstream_git_repo: Repo,
     upstream_repository_path: Path,
@@ -508,7 +510,7 @@ def test__run_migrate_with_pull_request_no_modification(
     act: when _run_migrate is called
     assert: docs are migrated and the remote branch is left intact.
     """
-    # mock_get_pull.return_value = "test-url"
+    mock_get_pull_request.return_value = mock_pull_request
 
     index_content = """Content header.
 

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -687,7 +687,7 @@ def test_run_no_docs_dir_no_tag(
     assert path_file.read_text(encoding="utf-8") == navlink_page
 
 
-@mock.patch("github.PullRequest.PullRequest.edit")
+@mock.patch("github.PullRequest.PullRequest")
 def test_run_migrate_same_content_local_and_server(mock_edit_pull_request, caplog, mocked_clients):
     """
     arrange: given a path with a metadata.yaml that has docs key and docs directory aligned
@@ -734,13 +734,17 @@ def test_run_migrate_same_content_local_and_server(mock_edit_pull_request, caplo
 
     assert not returned_migration_reports
     assert any("No community contribution found" in record.message for record in caplog.records)
-    assert not mock_edit_pull_request.called
+    edit_call_args = [
+        kwargs for name, args, kwargs in mock_edit_pull_request.mock_calls if name.endswith("edit")
+    ]
+    assert len(edit_call_args) == 0
 
 
 @mock.patch("src.repository.Client.get_pull_request")
-@mock.patch("github.PullRequest.PullRequest.edit")
+@mock.patch("github.PullRequest.PullRequest")
 def test_run_migrate_same_content_local_and_server_open_pr(
-    mocked_get_pull_request, mock_edit_pull_request, caplog, mocked_clients, mock_pull_request
+    mocked_get_pull_request, mock_edit_pull_request,
+    caplog, mocked_clients, mock_pull_request
 ):
     """
     arrange: given a path with a metadata.yaml that has docs key and docs directory aligned
@@ -789,4 +793,8 @@ def test_run_migrate_same_content_local_and_server_open_pr(
 
     assert not returned_migration_reports
     assert any("No community contribution found" in record.message for record in caplog.records)
-    assert mock_edit_pull_request.called
+    edit_call_args = [
+        kwargs for name, args, kwargs in mock_edit_pull_request.mock_calls if name.endswith("edit")
+    ]
+    assert len(edit_call_args) == 1
+    assert edit_call_args[0] == {"state": "closed"}

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -687,7 +687,8 @@ def test_run_no_docs_dir_no_tag(
     assert path_file.read_text(encoding="utf-8") == navlink_page
 
 
-def test_run_migrate_same_content_local_and_server(caplog, mocked_clients):
+@mock.patch("github.PullRequest.PullRequest.edit")
+def test_run_migrate_same_content_local_and_server(mock_edit_pull_request, caplog, mocked_clients):
     """
     arrange: given a path with a metadata.yaml that has docs key and docs directory aligned
         and mocked discourse (with tag and main branch aligned)
@@ -733,3 +734,61 @@ def test_run_migrate_same_content_local_and_server(caplog, mocked_clients):
 
     assert not returned_migration_reports
     assert any("No community contribution found" in record.message for record in caplog.records)
+    assert not mock_edit_pull_request.called
+
+
+@mock.patch("src.repository.Client.get_pull_request")
+@mock.patch("github.PullRequest.PullRequest.edit")
+def test_run_migrate_same_content_local_and_server_open_pr(
+    mocked_get_pull_request, mock_edit_pull_request, caplog, mocked_clients, mock_pull_request
+):
+    """
+    arrange: given a path with a metadata.yaml that has docs key and docs directory aligned
+        and mocked discourse (with tag and main branch aligned) and there is an open PR
+    act: when run_migrate is called
+    assert: then nothing is done as the two versions are the compatible and the PR is closed.
+    """
+    mocked_get_pull_request.return_value = mock_pull_request
+
+    repository_path = mocked_clients.repository.base_path
+
+    create_metadata_yaml(
+        content=f"{METADATA_NAME_KEY}: name 1\n" f"{METADATA_DOCS_KEY}: https://discourse/t/docs",
+        path=repository_path,
+    )
+    index_content = """Content header lorem.
+
+    Content body.\n"""
+    index_table = f"""{constants.NAVIGATION_TABLE_START}
+    | 1 | their-path-1 | [empty-navlink]() |
+    | 2 | their-file-1 | [file-navlink](/file-navlink) |"""
+    index_page = f"{index_content}{index_table}"
+    navlink_page = "file-navlink-content"
+    mocked_clients.discourse.retrieve_topic.side_effect = [index_page, navlink_page]
+
+    (docs_folder := mocked_clients.repository.base_path / "docs").mkdir()
+    (docs_folder / "index.md").write_text(index_content)
+    (docs_folder / "their-path-1").mkdir()
+    (docs_folder / "their-path-1" / "their-file-1.md").write_text(navlink_page)
+
+    mocked_clients.repository.switch(DEFAULT_BRANCH).update_branch(
+        "First document version", directory=None
+    )
+
+    user_inputs = factories.UserInputsFactory()
+    mocked_clients.repository.tag_commit(
+        DOCUMENTATION_TAG, mocked_clients.repository.current_commit
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        # run is repeated in unit tests / integration tests
+        returned_migration_reports = run_migrate(
+            clients=mocked_clients, user_inputs=user_inputs
+        )  # pylint: disable=duplicate-code
+
+    assert not returned_migration_reports
+    assert any("No community contribution found" in record.message for record in caplog.records)
+    assert mock_edit_pull_request.called
+
+

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -235,7 +235,7 @@ def test_create_pull_request(
         (docs_path / "placeholder.md").touch()
         returned_url = repository_client.create_pull_request(DOCUMENTATION_TAG)
 
-    assert returned_url == mock_pull_request.html_url
+    assert returned_url.html_url == mock_pull_request.html_url
 
 
 def test_tag_commit_tag_error(monkeypatch, repository_client: Client):
@@ -885,7 +885,7 @@ def test_get_single_pull_request(monkeypatch, repository_client: Client, mock_pu
     pull_request_link = repository_client.get_pull_request(repository.DEFAULT_BRANCH_NAME)
 
     assert pull_request_link is not None
-    assert pull_request_link == "test_url"
+    assert pull_request_link.html_url == "test_url"
 
 
 def test_get_non_existing_pull_request(monkeypatch, repository_client: Client, mock_pull_request):
@@ -985,7 +985,7 @@ def test_create_pull_request_existing_branch(
     (repository_path / docs_folder).mkdir()
     (repository_path / filler_file).write_text("filler-content")
 
-    pr_link = repository_client.create_pull_request(base=DEFAULT_BRANCH)
+    pull_request = repository_client.create_pull_request(base=DEFAULT_BRANCH)
 
     repository_client.switch(branch_name).pull()
 
@@ -993,7 +993,7 @@ def test_create_pull_request_existing_branch(
 
     # Make sure that the upload-charm-docs/migrate branch has now be overridden
     assert hash2 != hash3
-    assert pr_link == "test_url"
+    assert pull_request.html_url == "test_url"
 
 
 def test_create_pull_request_function(
@@ -1014,10 +1014,10 @@ def test_create_pull_request_function(
 
     repository_client.switch(DEFAULT_BRANCH)
 
-    returned_pr_link = repository_client.create_pull_request(base=DEFAULT_BRANCH)
+    pull_request = repository_client.create_pull_request(base=DEFAULT_BRANCH)
 
     upstream_git_repo.git.checkout(repository.DEFAULT_BRANCH_NAME)
-    assert returned_pr_link == mock_pull_request.html_url
+    assert pull_request.html_url == mock_pull_request.html_url
     assert (
         upstream_repository_path / DOCUMENTATION_FOLDER_NAME / filler_file
     ).read_text() == filler_text


### PR DESCRIPTION
I have noticed that a good feature could be to close open PR if github and Discourse matches. This should provide an automatic way to resolve conflicts or also revert PR opened that, given new tags, are no longer necessary