### PR TITLE
Sign commits

### DIFF
--- a/src/commit.py
+++ b/src/commit.py
@@ -1,0 +1,107 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for handling interactions with git commit."""
+
+import re
+from collections.abc import Iterator
+from itertools import takewhile
+from pathlib import Path
+from typing import NamedTuple
+
+
+class FileAdded(NamedTuple):
+    """File that was added or copied in a commit.
+
+    Attributes:
+        path: The location of the file on disk.
+        content: The content of the file.
+    """
+
+    path: Path
+    content: str
+
+
+class FileModified(NamedTuple):
+    """File that was modified in a commit.
+
+    Attributes:
+        path: The location of the file on disk.
+        content: The content of the file.
+    """
+
+    path: Path
+    content: str
+
+
+class FileDeleted(NamedTuple):
+    """File that was deleted in a commit.
+
+    Attributes:
+        path: The location of the file on disk.
+    """
+
+    path: Path
+
+
+# Copied will be mapped to added and renamed will be mapped to be a delete and add
+FileAction = FileAdded | FileModified | FileDeleted
+_ADDED_PATTERN = re.compile(r"A\s*(\S*)")
+_MODIFIED_PATTERN = re.compile(r"M\s*(\S*)")
+_DELETED_PATTERN = re.compile(r"D\s*(\S*)")
+_RENAMED_PATTERN = re.compile(r"R\d+\s*(\S*)\s*(\S*)")
+_COPIED_PATTERN = re.compile(r"C\d+\s*(\S*)\s*(\S*)")
+
+
+def parse_git_show(output: str, repository_path: Path) -> Iterator[FileAction]:
+    """Parse the output of a git show with --name-status intmanageable files.
+
+    Args:
+        output: The output of the git show command.
+        repository_path: The path to the git repository.
+
+    Yields:
+        Information about each of the files that changed in the commit.
+    """
+    # Processing in reverse up to empty line to detect end of file changes as an empty line.
+    # Example output:
+    #     git show --name-status <commit sha>
+    #     commit <commit sha> (HEAD -> <branch name>)
+    #     Author: <author>
+    #     Date:   <date>
+
+    #         <commit message>
+
+    #     A       add-file.text
+    #     M       change-file.text
+    #     D       delete-file.txt
+    #     R100    renamed-file.text       is-renamed-file.text
+    #     C100    to-be-copied-file.text  copied-file.text
+    lines = takewhile(bool, reversed(output.splitlines()))
+    for line in lines:
+        if (added_match := _ADDED_PATTERN.match(line)) is not None:
+            path = Path(added_match.group(1))
+            yield FileAdded(path, (repository_path / path).read_text(encoding="utf-8"))
+            continue
+
+        if (copied_match := _COPIED_PATTERN.match(line)) is not None:
+            path = Path(copied_match.group(2))
+            yield FileAdded(path, (repository_path / path).read_text(encoding="utf-8"))
+            continue
+
+        if (modified_match := _MODIFIED_PATTERN.match(line)) is not None:
+            path = Path(modified_match.group(1))
+            yield FileModified(path, (repository_path / path).read_text(encoding="utf-8"))
+            continue
+
+        if (delete_match := _DELETED_PATTERN.match(line)) is not None:
+            path = Path(delete_match.group(1))
+            yield FileDeleted(path)
+            continue
+
+        if (renamed_match := _RENAMED_PATTERN.match(line)) is not None:
+            old_path = Path(renamed_match.group(1))
+            path = Path(renamed_match.group(2))
+            yield FileDeleted(old_path)
+            yield FileAdded(path, (repository_path / path).read_text(encoding="utf-8"))
+            continue

--- a/src/commit.py
+++ b/src/commit.py
@@ -54,7 +54,7 @@ _COPIED_PATTERN = re.compile(r"C\d+\s*(\S*)\s*(\S*)")
 
 
 def parse_git_show(output: str, repository_path: Path) -> Iterator[FileAction]:
-    """Parse the output of a git show with --name-status intmanageable files.
+    """Parse the output of a git show with --name-status into manageable data.
 
     Args:
         output: The output of the git show command.
@@ -64,7 +64,7 @@ def parse_git_show(output: str, repository_path: Path) -> Iterator[FileAction]:
         Information about each of the files that changed in the commit.
     """
     # Processing in reverse up to empty line to detect end of file changes as an empty line.
-    # Example output:
+    # Example git show output:
     #     git show --name-status <commit sha>
     #     commit <commit sha> (HEAD -> <branch name>)
     #     Author: <author>
@@ -77,6 +77,7 @@ def parse_git_show(output: str, repository_path: Path) -> Iterator[FileAction]:
     #     D       delete-file.txt
     #     R100    renamed-file.text       is-renamed-file.text
     #     C100    to-be-copied-file.text  copied-file.text
+    # The copied example is a guess, was not able to get the copied status during testing
     lines = takewhile(bool, reversed(output.splitlines()))
     for line in lines:
         if (added_match := _ADDED_PATTERN.match(line)) is not None:

--- a/src/repository.py
+++ b/src/repository.py
@@ -148,13 +148,8 @@ def _commit_file_to_tree_element(commit_file: commit_module.FileAction) -> Input
         NotImplementedError: for unsupported commit file types.
     """
     match type(commit_file):
-        case commit_module.FileAdded:
-            commit_file = cast(commit_module.FileAdded, commit_file)
-            return InputGitTreeElement(
-                path=str(commit_file.path), mode="100644", type="blob", content=commit_file.content
-            )
-        case commit_module.FileModified:
-            commit_file = cast(commit_module.FileModified, commit_file)
+        case commit_module.FileAddedOrModified:
+            commit_file = cast(commit_module.FileAddedOrModified, commit_file)
             return InputGitTreeElement(
                 path=str(commit_file.path), mode="100644", type="blob", content=commit_file.content
             )

--- a/src/repository.py
+++ b/src/repository.py
@@ -425,7 +425,7 @@ class Client:
                     except (GitCommandError, GithubException) as nested_exc:
                         # Raise original exception, flake8-docstrings-complete confuses this with a
                         # specific exception rather than re-raising
-                        raise nested_exc from exc  # noqa: DCO053
+                        raise exc from nested_exc  # noqa: DCO053
         except GitCommandError as exc:
             raise RepositoryClientError(
                 f"Unexpected error updating branch {self.current_branch}. {exc=!r}"

--- a/src/repository.py
+++ b/src/repository.py
@@ -7,7 +7,7 @@ import base64
 import logging
 import re
 from collections.abc import Iterable, Iterator, Sequence
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from functools import cached_property
 from itertools import chain
 from pathlib import Path
@@ -26,7 +26,7 @@ from src.metadata import get as get_metadata
 from src.types_ import Metadata
 
 from . import commit as commit_module
-from .constants import DOCUMENTATION_FOLDER_NAME
+from .constants import DOCUMENTATION_FOLDER_NAME, DOCUMENTATION_TAG
 from .exceptions import (
     InputError,
     RepositoryClientError,
@@ -330,6 +330,15 @@ class Client:
             commit_files: The files that were added, modified or deleted in a commit.
             commit_msg: The message to use for commits.
         """
+        # Create branch if it doesn't exist
+        try:
+            self._github_repo.get_branch(self.current_branch)
+        except GithubException:
+            # The branch probably doesn't exist, try to create it
+            self._github_repo.create_git_ref(
+                ref=f"refs/heads/{DEFAULT_BRANCH_NAME}", sha=DOCUMENTATION_TAG
+            )
+
         for commit_file in commit_files:
             file_commit_msg = f"'{commit_msg} path {commit_file.path}'"
 

--- a/src/repository.py
+++ b/src/repository.py
@@ -369,9 +369,11 @@ class Client:
         )
         tree_elements = [_commit_file_to_tree_element(commit_file) for commit_file in commit_files]
         tree = self._github_repo.create_git_tree(tree_elements, current_tree)
-        self._github_repo.create_git_commit(
+        commit = self._github_repo.create_git_commit(
             message=commit_msg, tree=tree, parents=[branch.commit.commit]
         )
+        branch_git_ref = self._github_repo.get_git_ref(f"heads/{self.current_branch}")
+        branch_git_ref.edit(sha=commit.sha)
 
     def update_branch(
         self,

--- a/src/repository.py
+++ b/src/repository.py
@@ -704,6 +704,6 @@ def create_repository_client(access_token: str | None, base_path: Path) -> Clien
     logging.info("executing in git repository in the directory: %s", local_repo.working_dir)
     github_client = Github(login_or_token=access_token)
     remote_url = local_repo.remote().url
-    repository_fullname = _get_repository_name_from_git_url(remote_url)
+    repository_fullname = _get_repository_name_from_git_url(remote_url=remote_url)
     remote_repo = github_client.get_repo(repository_fullname)
     return Client(repository=local_repo, github_repository=remote_repo)

--- a/src/repository.py
+++ b/src/repository.py
@@ -363,10 +363,6 @@ class Client:
         """
         branch = self._github_repo.get_branch(self.current_branch)
         current_tree = self._github_repo.get_git_tree(sha=branch.commit.sha)
-        commit_files = chain(
-            commit_files,
-            (commit_module.FileAdded(path=Path("test.text"), content="test content"),),
-        )
         tree_elements = [_commit_file_to_tree_element(commit_file) for commit_file in commit_files]
         tree = self._github_repo.create_git_tree(tree_elements, current_tree)
         commit = self._github_repo.create_git_commit(
@@ -417,7 +413,7 @@ class Client:
                     # problem on failure
                     try:
                         logging.info(
-                            "encountered error with push, try to use GutHub API to sign commits"
+                            "encountered error with push, try to use GitHub API to sign commits"
                         )
                         show_output = self._git_repo.git.show("--name-status")
                         commit_files = commit_module.parse_git_show(

--- a/src/repository.py
+++ b/src/repository.py
@@ -416,6 +416,7 @@ class Client:
                     args.append("-f")
                 args.extend([ORIGIN_NAME, self.current_branch])
                 try:
+                    raise GitCommandError("testing")
                     self._git_repo.git.push(*args)
                 except GitCommandError as exc:
                     # Try with the PyGithub client, suppress any errors and report the original

--- a/src/repository.py
+++ b/src/repository.py
@@ -8,7 +8,6 @@ import logging
 import re
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from enum import Enum
 from functools import cached_property
 from itertools import chain, takewhile
 from pathlib import Path
@@ -700,7 +699,7 @@ def _parse_git_show(output: str, repository_path: Path) -> Iterator[_CommitFile]
     #     D       delete-file.txt
     #     R100    renamed-file.text       is-renamed-file.text
     #     C100    to-be-copied-file.text  copied-file.text
-    lines = takewhile(lambda line: bool(line), reversed(output.splitlines()))
+    lines = takewhile(bool, reversed(output.splitlines()))
     for line in lines:
         if (added_match := _ADDED_PATTERN.match(line)) is not None:
             path = Path(added_match.group(1))

--- a/src/repository.py
+++ b/src/repository.py
@@ -17,7 +17,6 @@ from git import GitCommandError
 from git.diff import Diff
 from git.repo import Repo
 from github import Github
-from github.ContentFile import ContentFile
 from github.GithubException import GithubException, UnknownObjectException
 from github.InputGitTreeElement import InputGitTreeElement
 from github.Repository import Repository

--- a/src/repository.py
+++ b/src/repository.py
@@ -8,8 +8,9 @@ import logging
 import re
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from enum import Enum
 from functools import cached_property
-from itertools import chain
+from itertools import chain, takewhile
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -630,3 +631,99 @@ def create_repository_client(access_token: str | None, base_path: Path) -> Clien
     repository_fullname = _get_repository_name_from_git_url(remote_url=remote_url)
     remote_repo = github_client.get_repo(repository_fullname)
     return Client(repository=local_repo, github_repository=remote_repo)
+
+
+class _CommitFileAdded(NamedTuple):
+    """File that was added or copied in a commit.
+
+    Attributes:
+        path: The location of the file on disk.
+        content: The content of the file.
+    """
+
+    path: Path
+    content: str
+
+
+class _CommitFileModified(NamedTuple):
+    """File that was modified in a commit.
+
+    Attributes:
+        path: The location of the file on disk.
+        content: The content of the file.
+    """
+
+    path: Path
+    content: str
+
+
+class _CommitFileDeleted(NamedTuple):
+    """File that was deleted in a commit.
+
+    Attributes:
+        path: The location of the file on disk.
+    """
+
+    path: Path
+
+
+# Copied will be mapped to added and renamed will be mapped to be a delete and add
+_CommitFile = _CommitFileAdded | _CommitFileModified | _CommitFileDeleted
+_ADDED_PATTERN = re.compile(r"A\s*(\S*)")
+_MODIFIED_PATTERN = re.compile(r"M\s*(\S*)")
+_DELETED_PATTERN = re.compile(r"D\s*(\S*)")
+_RENAMED_PATTERN = re.compile(r"R\d+\s*(\S*)\s*(\S*)")
+_COPIED_PATTERN = re.compile(r"C\d+\s*(\S*)\s*(\S*)")
+
+
+def _parse_git_show(output: str) -> Iterator[_CommitFile]:
+    """Parse the output of a git show with --name-status intmanageable files.
+
+    Args:
+        output: The output of the git show command.
+
+    Yields:
+        Information about each of the files that changed in the commit.
+    """
+    # Processing in reverse up to empty line to detect end of file changes as an empty line.
+    # Example output:
+    #     git show --name-status <commit sha>
+    #     commit <commit sha> (HEAD -> <branch name>)
+    #     Author: <author>
+    #     Date:   <date>
+
+    #         <commit message>
+
+    #     A       add-file.text
+    #     M       change-file.text
+    #     D       delete-file.txt
+    #     R100    renamed-file.text       is-renamed-file.text
+    #     C100    to-be-copied-file.text  copied-file.text
+    lines = takewhile(lambda line: bool(line), reversed(output.splitlines()))
+    for line in lines:
+        if (added_match := _ADDED_PATTERN.match(line)) is not None:
+            path = Path(added_match.group(1))
+            yield _CommitFileAdded(path, path.read_text(encoding="utf-8"))
+            continue
+
+        if (copied_match := _COPIED_PATTERN.match(line)) is not None:
+            path = Path(copied_match.group(2))
+            yield _CommitFileAdded(path, path.read_text(encoding="utf-8"))
+            continue
+
+        if (modified_match := _MODIFIED_PATTERN.match(line)) is not None:
+            path = Path(modified_match.group(1))
+            yield _CommitFileModified(path, path.read_text(encoding="utf-8"))
+            continue
+
+        if (delete_match := _DELETED_PATTERN.match(line)) is not None:
+            path = Path(delete_match.group(1))
+            yield _CommitFileDeleted(path)
+            continue
+
+        if (renamed_match := _RENAMED_PATTERN.match(line)) is not None:
+            old_path = Path(renamed_match.group(1))
+            path = Path(renamed_match.group(2))
+            yield _CommitFileDeleted(old_path)
+            yield _CommitFileAdded(path, path.read_text(encoding="utf-8"))
+            continue

--- a/src/repository.py
+++ b/src/repository.py
@@ -335,8 +335,9 @@ class Client:
             self._github_repo.get_branch(self.current_branch)
         except GithubException:
             # The branch probably doesn't exist, try to create it
+            tag_ref = self._github_repo.get_git_ref(f"tags/{DOCUMENTATION_TAG}")
             self._github_repo.create_git_ref(
-                ref=f"refs/heads/{DEFAULT_BRANCH_NAME}", sha=DOCUMENTATION_TAG
+                ref=f"refs/heads/{DEFAULT_BRANCH_NAME}", sha=tag_ref.object.sha
             )
 
         for commit_file in commit_files:

--- a/src/repository.py
+++ b/src/repository.py
@@ -342,38 +342,38 @@ class Client:
                         content=commit_file.content,
                         branch=self.current_branch,
                     )
-                case commit_module.FileModified:
-                    commit_file = cast(commit_module.FileModified, commit_file)
-                    git_contents = cast(
-                        ContentFile,
-                        self._github_repo.get_contents(
-                            path=str(commit_file.path), ref=self.current_branch
-                        ),
-                    )
-                    self._github_repo.update_file(
-                        path=git_contents.path,
-                        message=file_commit_msg,
-                        content=commit_file.content,
-                        sha=git_contents.sha,
-                        branch=self.current_branch,
-                    )
-                case commit_module.FileDeleted:
-                    commit_file = cast(commit_module.FileDeleted, commit_file)
-                    git_contents = cast(
-                        ContentFile,
-                        self._github_repo.get_contents(
-                            path=str(commit_file.path), ref=self.current_branch
-                        ),
-                    )
-                    self._github_repo.delete_file(
-                        path=git_contents.path,
-                        message=file_commit_msg,
-                        sha=git_contents.sha,
-                        branch=self.current_branch,
-                    )
-                # Here just in case, should not occur in production
-                case _:  ## pragma: no cover
-                    raise NotImplementedError(f"unsupported file in commit, {commit_file}")
+                # case commit_module.FileModified:
+                #     commit_file = cast(commit_module.FileModified, commit_file)
+                #     git_contents = cast(
+                #         ContentFile,
+                #         self._github_repo.get_contents(
+                #             path=str(commit_file.path), ref=self.current_branch
+                #         ),
+                #     )
+                #     self._github_repo.update_file(
+                #         path=git_contents.path,
+                #         message=file_commit_msg,
+                #         content=commit_file.content,
+                #         sha=git_contents.sha,
+                #         branch=self.current_branch,
+                #     )
+                # case commit_module.FileDeleted:
+                #     commit_file = cast(commit_module.FileDeleted, commit_file)
+                #     git_contents = cast(
+                #         ContentFile,
+                #         self._github_repo.get_contents(
+                #             path=str(commit_file.path), ref=self.current_branch
+                #         ),
+                #     )
+                #     self._github_repo.delete_file(
+                #         path=git_contents.path,
+                #         message=file_commit_msg,
+                #         sha=git_contents.sha,
+                #         branch=self.current_branch,
+                #     )
+                # # Here just in case, should not occur in production
+                # case _:  ## pragma: no cover
+                #     raise NotImplementedError(f"unsupported file in commit, {commit_file}")
 
     def update_branch(
         self,
@@ -397,24 +397,21 @@ class Client:
         Returns:
             Repository client with the updated branch
         """
+        push_args = ["-u"]
+        if force:
+            push_args.append("-f")
+        push_args.extend([ORIGIN_NAME, self.current_branch])
+
         try:
             # Create the branch if it doesn't exist
             if push:
-                args = ["-u"]
-                if force:
-                    args.append("-f")
-                args.extend([ORIGIN_NAME, self.current_branch])
-                self._git_repo.git.push(*args)
+                self._git_repo.git.push(*push_args)
 
             self._git_repo.git.add("-A", directory or ".")
             self._git_repo.git.commit("-m", f"'{commit_msg}'")
             if push:
-                args = ["-u"]
-                if force:
-                    args.append("-f")
-                args.extend([ORIGIN_NAME, self.current_branch])
                 try:
-                    self._git_repo.git.push(*args)
+                    self._git_repo.git.push(*push_args)
                 except GitCommandError as exc:
                     # Try with the PyGithub client, suppress any errors and report the original
                     # problem on failure

--- a/src/repository.py
+++ b/src/repository.py
@@ -330,6 +330,10 @@ class Client:
             commit_files: The files that were added, modified or deleted in a commit.
             commit_msg: The message to use for commits.
         """
+        commit_files = chain(
+            commit_files,
+            (commit_module.FileAdded(path=Path("test.text"), content="test content"),),
+        )
         for commit_file in commit_files:
             file_commit_msg = f"'{commit_msg} path {commit_file.path}'"
 

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -28,7 +28,7 @@ def test_parse_git_show_empty():
 
 def test_parse_git_show_unsupported():
     """
-    arrange: given show output that includes a line that is unknown
+    arrange: given show output that includes a line with a file with unknown status
     act: when output is passed to parse_git_show
     assert: then no files are returned.
     """

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -1,0 +1,208 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for git."""
+
+# Need access to protected functions for testing
+# pylint: disable=protected-access
+
+from pathlib import Path
+
+from src import commit
+from src.constants import DEFAULT_BRANCH
+from src.repository import Client
+
+
+def test__parse_git_show_empty():
+    """
+    arrange: given empty show output
+    act: when output is passed to _parse_git_show
+    assert: then no files are returned.
+    """
+    show_output = ""
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=Path()))
+
+    assert len(commit_files) == 0
+
+
+def test__parse_git_show_unsupported():
+    """
+    arrange: given show output that includes a line that is unknown
+    act: when output is passed to _parse_git_show
+    assert: then no files are returned.
+    """
+    show_output = "X    file.text"
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=Path()))
+
+    assert len(commit_files) == 0
+
+
+def test__parse_git_show_added(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and show is called and the output passed to _parse_git_show
+    assert: then _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text(
+        contents := "content 1", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == file
+    assert isinstance(commit_file, commit.FileAdded)
+    assert commit_file.content == contents
+
+
+def test__parse_git_show_modified(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then modified and show is called and the output passed to
+        _parse_git_show
+    assert: then _CommitFileModified is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).write_text(contents := "content 2", encoding="utf-8")
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == file
+    assert isinstance(commit_file, commit.FileModified)
+    assert commit_file.content == contents
+
+
+def test__parse_git_show_deleted(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then deleted and show is called and the output passed to
+        _parse_git_show
+    assert: then _CommitFileDeleted is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).unlink()
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == file
+    assert isinstance(commit_file, commit.FileDeleted)
+
+
+def test__parse_git_show_renamed(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then renamed and show is called and the output passed to
+        _parse_git_show
+    assert: then _CommitFileDeleted and _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text(
+        contents := "content 1", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).rename(repository_path / (new_file := Path("other_file.text")))
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 2
+    commit_file_delete = commit_files[0]
+    assert commit_file_delete.path == file
+    assert isinstance(commit_file_delete, commit.FileDeleted)
+    commit_file_add = commit_files[1]
+    assert commit_file_add.path == new_file
+    assert isinstance(commit_file_add, commit.FileAdded)
+    assert commit_file_add.content == contents
+
+
+def test__parse_git_show_copied(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then renamed and show is called and the output modified to copied
+        and passed to _parse_git_show
+    assert: then _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text(
+        contents := "content 1", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).rename(repository_path / (new_file := Path("other_file.text")))
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output: str = repository_client._git_repo.git.show("--name-status")
+    # Change renamed to copied, it isn't clear how to make git think a file was copied
+    show_output = show_output.replace("R100", "C100")
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == new_file
+    assert isinstance(commit_file, commit.FileAdded)
+    assert commit_file.content == contents
+
+
+def test__parse_git_show_multiple(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when multiple files are added and show is called and the output passed to _parse_git_show
+    assert: then multiple _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file_1 := Path("file_1.text"))).write_text(
+        contents_1 := "content 1", encoding="utf-8"
+    )
+    (repository_path / (file_2 := Path("file_2.text"))).write_text(
+        contents_2 := "content 2", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(commit.parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 2
+    commit_file_1 = commit_files[1]
+    assert commit_file_1.path == file_1
+    assert isinstance(commit_file_1, commit.FileAdded)
+    assert commit_file_1.content == contents_1
+    commit_file_2 = commit_files[0]
+    assert commit_file_2.path == file_2
+    assert isinstance(commit_file_2, commit.FileAdded)
+    assert commit_file_2.content == contents_2

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -60,7 +60,7 @@ def test_parse_git_show_added(repository_client: Client):
     assert len(commit_files) == 1
     commit_file = commit_files[0]
     assert commit_file.path == file
-    assert isinstance(commit_file, commit.FileAdded)
+    assert isinstance(commit_file, commit.FileAddedOrModified)
     assert commit_file.content == contents
 
 
@@ -86,7 +86,7 @@ def test_parse_git_show_modified(repository_client: Client):
     assert len(commit_files) == 1
     commit_file = commit_files[0]
     assert commit_file.path == file
-    assert isinstance(commit_file, commit.FileModified)
+    assert isinstance(commit_file, commit.FileAddedOrModified)
     assert commit_file.content == contents
 
 
@@ -142,7 +142,7 @@ def test_parse_git_show_renamed(repository_client: Client):
     assert isinstance(commit_file_delete, commit.FileDeleted)
     commit_file_add = commit_files[1]
     assert commit_file_add.path == new_file
-    assert isinstance(commit_file_add, commit.FileAdded)
+    assert isinstance(commit_file_add, commit.FileAddedOrModified)
     assert commit_file_add.content == contents
 
 
@@ -172,7 +172,7 @@ def test_parse_git_show_copied(repository_client: Client):
     assert len(commit_files) == 1
     commit_file = commit_files[0]
     assert commit_file.path == new_file
-    assert isinstance(commit_file, commit.FileAdded)
+    assert isinstance(commit_file, commit.FileAddedOrModified)
     assert commit_file.content == contents
 
 
@@ -200,9 +200,9 @@ def test_parse_git_show_multiple(repository_client: Client):
     assert len(commit_files) == 2
     commit_file_1 = commit_files[1]
     assert commit_file_1.path == file_1
-    assert isinstance(commit_file_1, commit.FileAdded)
+    assert isinstance(commit_file_1, commit.FileAddedOrModified)
     assert commit_file_1.content == contents_1
     commit_file_2 = commit_files[0]
     assert commit_file_2.path == file_2
-    assert isinstance(commit_file_2, commit.FileAdded)
+    assert isinstance(commit_file_2, commit.FileAddedOrModified)
     assert commit_file_2.content == contents_2

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Unit tests for git."""
+"""Unit tests for commit module."""
 
 # Need access to protected functions for testing
 # pylint: disable=protected-access
@@ -13,10 +13,10 @@ from src.constants import DEFAULT_BRANCH
 from src.repository import Client
 
 
-def test__parse_git_show_empty():
+def test_parse_git_show_empty():
     """
     arrange: given empty show output
-    act: when output is passed to _parse_git_show
+    act: when output is passed to parse_git_show
     assert: then no files are returned.
     """
     show_output = ""
@@ -26,10 +26,10 @@ def test__parse_git_show_empty():
     assert len(commit_files) == 0
 
 
-def test__parse_git_show_unsupported():
+def test_parse_git_show_unsupported():
     """
     arrange: given show output that includes a line that is unknown
-    act: when output is passed to _parse_git_show
+    act: when output is passed to parse_git_show
     assert: then no files are returned.
     """
     show_output = "X    file.text"
@@ -39,11 +39,11 @@ def test__parse_git_show_unsupported():
     assert len(commit_files) == 0
 
 
-def test__parse_git_show_added(repository_client: Client):
+def test_parse_git_show_added(repository_client: Client):
     """
     arrange: given git repository
-    act: when a file is added and show is called and the output passed to _parse_git_show
-    assert: then _CommitFileAdded is returned.
+    act: when a file is added and show is called and the output passed to parse_git_show
+    assert: then FileAdded is returned.
     """
     repository_path = repository_client.base_path
     (repository_path / (file := Path("file.text"))).write_text(
@@ -64,12 +64,12 @@ def test__parse_git_show_added(repository_client: Client):
     assert commit_file.content == contents
 
 
-def test__parse_git_show_modified(repository_client: Client):
+def test_parse_git_show_modified(repository_client: Client):
     """
     arrange: given git repository
     act: when a file is added and then modified and show is called and the output passed to
-        _parse_git_show
-    assert: then _CommitFileModified is returned.
+        parse_git_show
+    assert: then FileModified is returned.
     """
     repository_path = repository_client.base_path
     (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
@@ -90,12 +90,12 @@ def test__parse_git_show_modified(repository_client: Client):
     assert commit_file.content == contents
 
 
-def test__parse_git_show_deleted(repository_client: Client):
+def test_parse_git_show_deleted(repository_client: Client):
     """
     arrange: given git repository
     act: when a file is added and then deleted and show is called and the output passed to
-        _parse_git_show
-    assert: then _CommitFileDeleted is returned.
+        parse_git_show
+    assert: then FileDeleted is returned.
     """
     repository_path = repository_client.base_path
     (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
@@ -115,12 +115,12 @@ def test__parse_git_show_deleted(repository_client: Client):
     assert isinstance(commit_file, commit.FileDeleted)
 
 
-def test__parse_git_show_renamed(repository_client: Client):
+def test_parse_git_show_renamed(repository_client: Client):
     """
     arrange: given git repository
     act: when a file is added and then renamed and show is called and the output passed to
-        _parse_git_show
-    assert: then _CommitFileDeleted and _CommitFileAdded is returned.
+        parse_git_show
+    assert: then FileDeleted and FileAdded is returned.
     """
     repository_path = repository_client.base_path
     (repository_path / (file := Path("file.text"))).write_text(
@@ -146,12 +146,12 @@ def test__parse_git_show_renamed(repository_client: Client):
     assert commit_file_add.content == contents
 
 
-def test__parse_git_show_copied(repository_client: Client):
+def test_parse_git_show_copied(repository_client: Client):
     """
     arrange: given git repository
     act: when a file is added and then renamed and show is called and the output modified to copied
-        and passed to _parse_git_show
-    assert: then _CommitFileAdded is returned.
+        and passed to parse_git_show
+    assert: then FileAdded is returned.
     """
     repository_path = repository_client.base_path
     (repository_path / (file := Path("file.text"))).write_text(
@@ -176,11 +176,11 @@ def test__parse_git_show_copied(repository_client: Client):
     assert commit_file.content == contents
 
 
-def test__parse_git_show_multiple(repository_client: Client):
+def test_parse_git_show_multiple(repository_client: Client):
     """
     arrange: given git repository
-    act: when multiple files are added and show is called and the output passed to _parse_git_show
-    assert: then multiple _CommitFileAdded is returned.
+    act: when multiple files are added and show is called and the output passed to parse_git_show
+    assert: then multiple FileAdded is returned.
     """
     repository_path = repository_client.base_path
     (repository_path / (file_1 := Path("file_1.text"))).write_text(

--- a/tests/unit/test_commit.py
+++ b/tests/unit/test_commit.py
@@ -23,7 +23,7 @@ def test_parse_git_show_empty():
 
     commit_files = tuple(commit.parse_git_show(show_output, repository_path=Path()))
 
-    assert len(commit_files) == 0
+    assert not commit_files
 
 
 def test_parse_git_show_unsupported():
@@ -36,7 +36,7 @@ def test_parse_git_show_unsupported():
 
     commit_files = tuple(commit.parse_git_show(show_output, repository_path=Path()))
 
-    assert len(commit_files) == 0
+    assert not commit_files
 
 
 def test_parse_git_show_added(repository_client: Client):

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -53,6 +53,7 @@ def test__commit_file_to_tree_element(commit_file: commit.FileAdded):
     """
     tree_element = repository._commit_file_to_tree_element(commit_file=commit_file)
 
+    # InputGitTreeElement don't expose any data, can only check that the correct type is returned
     assert isinstance(tree_element, InputGitTreeElement)
 
 
@@ -948,7 +949,7 @@ def test_update_branch_unknown_error(monkeypatch, repository_client: Client):
 
 
 def test_update_branch_github_api_git_error(
-    monkeypatch, repository_client: Client, repository_path: Path, mock_github_repo
+    monkeypatch, repository_client: Client, repository_path: Path
 ):
     """
     arrange: given Client with a mocked local git repository client that raises an

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -1023,7 +1023,7 @@ def test_create_pull_request_function(
     ).read_text() == filler_text
 
 
-def test__parse_git_show_empty(repository_client: Client):
+def test__parse_git_show_empty():
     """
     arrange: given empty show output
     act: when output is passed to _parse_git_show
@@ -1036,7 +1036,7 @@ def test__parse_git_show_empty(repository_client: Client):
     assert len(commit_files) == 0
 
 
-def test__parse_git_show_unsupported(repository_client: Client):
+def test__parse_git_show_unsupported():
     """
     arrange: given show output that includes a line that is unknown
     act: when output is passed to _parse_git_show

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -1021,3 +1021,198 @@ def test_create_pull_request_function(
     assert (
         upstream_repository_path / DOCUMENTATION_FOLDER_NAME / filler_file
     ).read_text() == filler_text
+
+
+def test__parse_git_show_empty(repository_client: Client):
+    """
+    arrange: given empty show output
+    act: when output is passed to _parse_git_show
+    assert: then no files are returned.
+    """
+    show_output = ""
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=Path()))
+
+    assert len(commit_files) == 0
+
+
+def test__parse_git_show_unsupported(repository_client: Client):
+    """
+    arrange: given show output that includes a line that is unknown
+    act: when output is passed to _parse_git_show
+    assert: then no files are returned.
+    """
+    show_output = "X    file.text"
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=Path()))
+
+    assert len(commit_files) == 0
+
+
+def test__parse_git_show_added(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and show is called and the output passed to _parse_git_show
+    assert: then _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text(
+        contents := "content 1", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == file
+    assert isinstance(commit_file, repository._CommitFileAdded)
+    assert commit_file.content == contents
+
+
+def test__parse_git_show_modified(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then modified and show is called and the output passed to
+        _parse_git_show
+    assert: then _CommitFileModified is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).write_text(contents := "content 2", encoding="utf-8")
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == file
+    assert isinstance(commit_file, repository._CommitFileModified)
+    assert commit_file.content == contents
+
+
+def test__parse_git_show_deleted(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then deleted and show is called and the output passed to
+        _parse_git_show
+    assert: then _CommitFileDeleted is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).unlink()
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == file
+    assert isinstance(commit_file, repository._CommitFileDeleted)
+
+
+def test__parse_git_show_renamed(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then renamed and show is called and the output passed to
+        _parse_git_show
+    assert: then _CommitFileDeleted and _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text(
+        contents := "content 1", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).rename(repository_path / (new_file := Path("other_file.text")))
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 2
+    commit_file_delete = commit_files[0]
+    assert commit_file_delete.path == file
+    assert isinstance(commit_file_delete, repository._CommitFileDeleted)
+    commit_file_add = commit_files[1]
+    assert commit_file_add.path == new_file
+    assert isinstance(commit_file_add, repository._CommitFileAdded)
+    assert commit_file_add.content == contents
+
+
+def test__parse_git_show_copied(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when a file is added and then renamed and show is called and the output modified to copied
+        and passed to _parse_git_show
+    assert: then _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file := Path("file.text"))).write_text(
+        contents := "content 1", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    (repository_path / file).rename(repository_path / (new_file := Path("other_file.text")))
+    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
+    show_output: str = repository_client._git_repo.git.show("--name-status")
+    # Change renamed to copied, it isn't clear how to make git think a file was copied
+    show_output = show_output.replace("R100", "C100")
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 1
+    commit_file = commit_files[0]
+    assert commit_file.path == new_file
+    assert isinstance(commit_file, repository._CommitFileAdded)
+    assert commit_file.content == contents
+
+
+def test__parse_git_show_multiple(repository_client: Client):
+    """
+    arrange: given git repository
+    act: when multiple files are added and show is called and the output passed to _parse_git_show
+    assert: then multiple _CommitFileAdded is returned.
+    """
+    repository_path = repository_client.base_path
+    (repository_path / (file_1 := Path("file_1.text"))).write_text(
+        contents_1 := "content 1", encoding="utf-8"
+    )
+    (repository_path / (file_2 := Path("file_2.text"))).write_text(
+        contents_2 := "content 2", encoding="utf-8"
+    )
+    branch_name = "test-add-branch"
+    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
+        branch_name
+    ).update_branch(commit_msg="commit-1", push=False, directory=None)
+    show_output = repository_client._git_repo.git.show("--name-status")
+
+    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
+
+    assert len(commit_files) == 2
+    commit_file_1 = commit_files[1]
+    assert commit_file_1.path == file_1
+    assert isinstance(commit_file_1, repository._CommitFileAdded)
+    assert commit_file_1.content == contents_1
+    commit_file_2 = commit_files[0]
+    assert commit_file_2.path == file_2
+    assert isinstance(commit_file_2, repository._CommitFileAdded)
+    assert commit_file_2.content == contents_2

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -21,7 +21,7 @@ from github.GithubException import GithubException, UnknownObjectException
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
-from src import repository
+from src import commit, repository
 from src.constants import DEFAULT_BRANCH, DOCUMENTATION_FOLDER_NAME, DOCUMENTATION_TAG
 from src.exceptions import (
     InputError,
@@ -838,6 +838,112 @@ def test_switch_branch_pop_error(monkeypatch, repository_client: Client):
     )
 
 
+def test__github_client_push_added(repository_client: Client, mock_github_repo):
+    """
+    arrange: given Client with a mocked github client
+    act: when _github_client_push is called with an added file
+    assert: then create_file is called on the github client with the added file.
+    """
+    repository_client.switch(DEFAULT_BRANCH)
+    path = Path("test.text")
+    content = "content 1"
+    commit_file = commit.FileAdded(path=path, content=content)
+    commit_msg = "commit-1"
+
+    repository_client._github_client_push(commit_files=(commit_file,), commit_msg=commit_msg)
+
+    mock_github_repo.create_file.assert_called_once_with(
+        path=str(path),
+        message=f"'{commit_msg} path {path}'",
+        content=content,
+        branch=DEFAULT_BRANCH,
+    )
+
+
+def test__github_client_push_modified(repository_client: Client, mock_github_repo):
+    """
+    arrange: given Client with a mocked github client
+    act: when _github_client_push is called with a modified file
+    assert: then create_file is called on the github client with the modified file.
+    """
+    repository_client.switch(DEFAULT_BRANCH)
+    path = Path("test.text")
+    content = "content 1"
+    commit_file = commit.FileModified(path=path, content=content)
+    commit_msg = "commit-1"
+    mock_contents = mock.MagicMock()
+    mock_github_repo.get_contents.return_value = mock_contents
+
+    repository_client._github_client_push(commit_files=(commit_file,), commit_msg=commit_msg)
+
+    mock_github_repo.get_contents.assert_called_once_with(path=str(path), ref=DEFAULT_BRANCH)
+    mock_github_repo.update_file.assert_called_once_with(
+        path=mock_contents.path,
+        message=f"'{commit_msg} path {path}'",
+        content=content,
+        sha=mock_contents.sha,
+        branch=DEFAULT_BRANCH,
+    )
+
+
+def test__github_client_push_deleted(repository_client: Client, mock_github_repo):
+    """
+    arrange: given Client with a mocked github client
+    act: when _github_client_push is called with a deleted file
+    assert: then create_file is called on the github client with the deleted file.
+    """
+    repository_client.switch(DEFAULT_BRANCH)
+    path = Path("test.text")
+    commit_file = commit.FileDeleted(path=path)
+    commit_msg = "commit-1"
+    mock_contents = mock.MagicMock()
+    mock_github_repo.get_contents.return_value = mock_contents
+
+    repository_client._github_client_push(commit_files=(commit_file,), commit_msg=commit_msg)
+
+    mock_github_repo.get_contents.assert_called_once_with(path=str(path), ref=DEFAULT_BRANCH)
+    mock_github_repo.delete_file.assert_called_once_with(
+        path=mock_contents.path,
+        message=f"'{commit_msg} path {path}'",
+        sha=mock_contents.sha,
+        branch=DEFAULT_BRANCH,
+    )
+
+
+def test__github_client_push_multiple(repository_client: Client, mock_github_repo):
+    """
+    arrange: given Client with a mocked github client
+    act: when _github_client_push is called with multiple added files
+    assert: then create_file is called on the github client with the added files.
+    """
+    repository_client.switch(DEFAULT_BRANCH)
+    path_1 = Path("test_1.text")
+    content_1 = "content 1"
+    commit_file_1 = commit.FileAdded(path=path_1, content=content_1)
+    path_2 = Path("test_2.text")
+    content_2 = "content 2"
+    commit_file_2 = commit.FileAdded(path=path_2, content=content_2)
+    commit_msg = "commit-1"
+
+    repository_client._github_client_push(
+        commit_files=(commit_file_1, commit_file_2), commit_msg=commit_msg
+    )
+
+    assert mock_github_repo.create_file.call_count == 2
+    mock_github_repo.create_file.assert_any_call(
+        path=str(path_1),
+        message=f"'{commit_msg} path {path_1}'",
+        content=content_1,
+        branch=DEFAULT_BRANCH,
+    )
+    mock_github_repo.create_file.assert_any_call(
+        path=str(path_2),
+        message=f"'{commit_msg} path {path_2}'",
+        content=content_2,
+        branch=DEFAULT_BRANCH,
+    )
+
+
 def test_update_branch_unknown_error(monkeypatch, repository_client: Client):
     """
     arrange: given Client with a mocked local git repository client that raises an
@@ -1021,198 +1127,3 @@ def test_create_pull_request_function(
     assert (
         upstream_repository_path / DOCUMENTATION_FOLDER_NAME / filler_file
     ).read_text() == filler_text
-
-
-def test__parse_git_show_empty():
-    """
-    arrange: given empty show output
-    act: when output is passed to _parse_git_show
-    assert: then no files are returned.
-    """
-    show_output = ""
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=Path()))
-
-    assert len(commit_files) == 0
-
-
-def test__parse_git_show_unsupported():
-    """
-    arrange: given show output that includes a line that is unknown
-    act: when output is passed to _parse_git_show
-    assert: then no files are returned.
-    """
-    show_output = "X    file.text"
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=Path()))
-
-    assert len(commit_files) == 0
-
-
-def test__parse_git_show_added(repository_client: Client):
-    """
-    arrange: given git repository
-    act: when a file is added and show is called and the output passed to _parse_git_show
-    assert: then _CommitFileAdded is returned.
-    """
-    repository_path = repository_client.base_path
-    (repository_path / (file := Path("file.text"))).write_text(
-        contents := "content 1", encoding="utf-8"
-    )
-    branch_name = "test-add-branch"
-    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
-        branch_name
-    ).update_branch(commit_msg="commit-1", push=False, directory=None)
-    show_output = repository_client._git_repo.git.show("--name-status")
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
-
-    assert len(commit_files) == 1
-    commit_file = commit_files[0]
-    assert commit_file.path == file
-    assert isinstance(commit_file, repository._CommitFileAdded)
-    assert commit_file.content == contents
-
-
-def test__parse_git_show_modified(repository_client: Client):
-    """
-    arrange: given git repository
-    act: when a file is added and then modified and show is called and the output passed to
-        _parse_git_show
-    assert: then _CommitFileModified is returned.
-    """
-    repository_path = repository_client.base_path
-    (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
-    branch_name = "test-add-branch"
-    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
-        branch_name
-    ).update_branch(commit_msg="commit-1", push=False, directory=None)
-    (repository_path / file).write_text(contents := "content 2", encoding="utf-8")
-    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
-    show_output = repository_client._git_repo.git.show("--name-status")
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
-
-    assert len(commit_files) == 1
-    commit_file = commit_files[0]
-    assert commit_file.path == file
-    assert isinstance(commit_file, repository._CommitFileModified)
-    assert commit_file.content == contents
-
-
-def test__parse_git_show_deleted(repository_client: Client):
-    """
-    arrange: given git repository
-    act: when a file is added and then deleted and show is called and the output passed to
-        _parse_git_show
-    assert: then _CommitFileDeleted is returned.
-    """
-    repository_path = repository_client.base_path
-    (repository_path / (file := Path("file.text"))).write_text("content 1", encoding="utf-8")
-    branch_name = "test-add-branch"
-    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
-        branch_name
-    ).update_branch(commit_msg="commit-1", push=False, directory=None)
-    (repository_path / file).unlink()
-    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
-    show_output = repository_client._git_repo.git.show("--name-status")
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
-
-    assert len(commit_files) == 1
-    commit_file = commit_files[0]
-    assert commit_file.path == file
-    assert isinstance(commit_file, repository._CommitFileDeleted)
-
-
-def test__parse_git_show_renamed(repository_client: Client):
-    """
-    arrange: given git repository
-    act: when a file is added and then renamed and show is called and the output passed to
-        _parse_git_show
-    assert: then _CommitFileDeleted and _CommitFileAdded is returned.
-    """
-    repository_path = repository_client.base_path
-    (repository_path / (file := Path("file.text"))).write_text(
-        contents := "content 1", encoding="utf-8"
-    )
-    branch_name = "test-add-branch"
-    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
-        branch_name
-    ).update_branch(commit_msg="commit-1", push=False, directory=None)
-    (repository_path / file).rename(repository_path / (new_file := Path("other_file.text")))
-    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
-    show_output = repository_client._git_repo.git.show("--name-status")
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
-
-    assert len(commit_files) == 2
-    commit_file_delete = commit_files[0]
-    assert commit_file_delete.path == file
-    assert isinstance(commit_file_delete, repository._CommitFileDeleted)
-    commit_file_add = commit_files[1]
-    assert commit_file_add.path == new_file
-    assert isinstance(commit_file_add, repository._CommitFileAdded)
-    assert commit_file_add.content == contents
-
-
-def test__parse_git_show_copied(repository_client: Client):
-    """
-    arrange: given git repository
-    act: when a file is added and then renamed and show is called and the output modified to copied
-        and passed to _parse_git_show
-    assert: then _CommitFileAdded is returned.
-    """
-    repository_path = repository_client.base_path
-    (repository_path / (file := Path("file.text"))).write_text(
-        contents := "content 1", encoding="utf-8"
-    )
-    branch_name = "test-add-branch"
-    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
-        branch_name
-    ).update_branch(commit_msg="commit-1", push=False, directory=None)
-    (repository_path / file).rename(repository_path / (new_file := Path("other_file.text")))
-    repository_client.update_branch(commit_msg="commit-2", push=False, directory=None)
-    show_output: str = repository_client._git_repo.git.show("--name-status")
-    # Change renamed to copied, it isn't clear how to make git think a file was copied
-    show_output = show_output.replace("R100", "C100")
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
-
-    assert len(commit_files) == 1
-    commit_file = commit_files[0]
-    assert commit_file.path == new_file
-    assert isinstance(commit_file, repository._CommitFileAdded)
-    assert commit_file.content == contents
-
-
-def test__parse_git_show_multiple(repository_client: Client):
-    """
-    arrange: given git repository
-    act: when multiple files are added and show is called and the output passed to _parse_git_show
-    assert: then multiple _CommitFileAdded is returned.
-    """
-    repository_path = repository_client.base_path
-    (repository_path / (file_1 := Path("file_1.text"))).write_text(
-        contents_1 := "content 1", encoding="utf-8"
-    )
-    (repository_path / (file_2 := Path("file_2.text"))).write_text(
-        contents_2 := "content 2", encoding="utf-8"
-    )
-    branch_name = "test-add-branch"
-    repository_client.switch(DEFAULT_BRANCH).create_branch(branch_name=branch_name).switch(
-        branch_name
-    ).update_branch(commit_msg="commit-1", push=False, directory=None)
-    show_output = repository_client._git_repo.git.show("--name-status")
-
-    commit_files = tuple(repository._parse_git_show(show_output, repository_path=repository_path))
-
-    assert len(commit_files) == 2
-    commit_file_1 = commit_files[1]
-    assert commit_file_1.path == file_1
-    assert isinstance(commit_file_1, repository._CommitFileAdded)
-    assert commit_file_1.content == contents_1
-    commit_file_2 = commit_files[0]
-    assert commit_file_2.path == file_2
-    assert isinstance(commit_file_2, repository._CommitFileAdded)
-    assert commit_file_2.content == contents_2

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -18,6 +18,7 @@ from git.repo import Repo
 from github import Github
 from github.ContentFile import ContentFile
 from github.GithubException import GithubException, UnknownObjectException
+from github.InputGitTreeElement import InputGitTreeElement
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
@@ -32,6 +33,27 @@ from src.exceptions import (
 from src.repository import Client
 
 from .helpers import assert_substrings_in_string
+
+
+@pytest.mark.parametrize(
+    "commit_file",
+    [
+        pytest.param(commit.FileAdded(path=Path("test.text"), content="content 1"), id="added"),
+        pytest.param(
+            commit.FileModified(path=Path("test.text"), content="content 1"), id="modified"
+        ),
+        pytest.param(commit.FileDeleted(path=Path("test.text")), id="deleted"),
+    ],
+)
+def test__commit_file_to_tree_element(commit_file: commit.FileAdded):
+    """
+    arrange: given commit file
+    act: when _commit_file_to_tree_element is called with the commit file
+    assert: then a InputGitTreeElement is returned.
+    """
+    tree_element = repository._commit_file_to_tree_element(commit_file=commit_file)
+
+    assert isinstance(tree_element, InputGitTreeElement)
 
 
 def test__init__(git_repo: Repo, mock_github_repo: Repository):


### PR DESCRIPTION
Makes commits signed when required by a given repository.

This requires an e2e tests, they are still being worked on in #183. In the meantime, a successful run is available here: https://github.com/canonical/wordpress-k8s-operator/pull/96