### PR TITLE
[MISC] Update tag for same content

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -97,16 +97,16 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
         return ReconcileOutputs(
             index_url=index.server.url if index.server else "",
             topics=(
-                {clients.discourse.absolute_url(index.server.url): ActionResult.SKIP}
-                if index.server
-                else {}
-            )
-            | (
                 {
                     f"{clients.discourse.absolute_url(row.navlink.link)}": ActionResult.SKIP
                     for row in table_rows
                     if row.navlink.link
                 }
+            )
+            | (
+                {clients.discourse.absolute_url(index.server.url): ActionResult.SKIP}
+                if index.server
+                else {}
             ),
             documentation_tag=clients.repository.tag_exists(DOCUMENTATION_TAG),
         )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -74,7 +74,7 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
     sorted_path_infos = sort_module.using_contents_index(
         path_infos=path_infos, index_contents=index_contents, docs_path=docs_path
     )
-    table_rows = navigation_table.from_page(page=server_content, discourse=clients.discourse)
+    table_rows = list(navigation_table.from_page(page=server_content, discourse=clients.discourse))
     actions = reconcile.run(
         sorted_path_infos=sorted_path_infos,
         table_rows=table_rows,
@@ -93,9 +93,10 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
         if clients.repository.is_commit_in_branch(user_inputs.commit_sha, user_inputs.base_branch):
             # This means we are running from the base_branch
             clients.repository.tag_commit(DOCUMENTATION_TAG, user_inputs.commit_sha)
+
         return ReconcileOutputs(
             index_url=index.server.url if index.server else "",
-            topics={},
+            topics={row.navlink.link: ActionResult.SKIP for row in table_rows if row.navlink.link},
             documentation_tag=clients.repository.tag_exists(DOCUMENTATION_TAG),
         )
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -87,11 +87,13 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
     actions, check_actions = tee(actions, 2)
     if reconcile.is_same_content(index, check_actions):
         logging.info(
-            "Reconcile not required to run as the content is the same on "
-            "Discourse and Github. Updating the tag."
+            "Reconcile not required to run as the content is the same on Discourse and Github."
         )
         if clients.repository.is_commit_in_branch(user_inputs.commit_sha, user_inputs.base_branch):
             # This means we are running from the base_branch
+            logging.info(
+                "Updating the tag %s on commit %s", DOCUMENTATION_TAG, user_inputs.commit_sha
+            )
             clients.repository.tag_commit(DOCUMENTATION_TAG, user_inputs.commit_sha)
 
         return ReconcileOutputs(

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -96,7 +96,18 @@ def run_reconcile(clients: Clients, user_inputs: UserInputs) -> ReconcileOutputs
 
         return ReconcileOutputs(
             index_url=index.server.url if index.server else "",
-            topics={row.navlink.link: ActionResult.SKIP for row in table_rows if row.navlink.link},
+            topics=(
+                {clients.discourse.absolute_url(index.server.url): ActionResult.SKIP}
+                if index.server
+                else {}
+            )
+            | (
+                {
+                    f"{clients.discourse.absolute_url(row.navlink.link)}": ActionResult.SKIP
+                    for row in table_rows
+                    if row.navlink.link
+                }
+            ),
             documentation_tag=clients.repository.tag_exists(DOCUMENTATION_TAG),
         )
 

--- a/src/reconcile.py
+++ b/src/reconcile.py
@@ -173,13 +173,8 @@ def _is_same_content(action: types_.AnyAction) -> bool:
     Returns:
         Boolean true if the contents match, false otherwise
     """
-    match action:
-        case types_.NoopAction(_, _, _, _):
-            return True
-        case types_.UpdateAction(_, _, _, content):
-            if not content:
-                return True
-            return content.local == content.server
+    if isinstance(action, types_.NoopAction):
+        return True
     return False
 
 

--- a/src/reconcile.py
+++ b/src/reconcile.py
@@ -188,7 +188,7 @@ def is_same_content(index: types_.Index, actions: typing.Iterable[types_.AnyActi
 
     Args:
         index: Index object representing local and server content for the index file
-        actions: List of actions representing what the reconcile actions over all topics
+        actions: List of actions representing what the reconcile action would do over all topics
 
     Returns:
         Boolean true if the contents match, false otherwise

--- a/src/reconcile.py
+++ b/src/reconcile.py
@@ -164,6 +164,44 @@ def _local_and_server_dir_local_page_server(
     )
 
 
+def _is_same_content(action: types_.AnyAction) -> bool:
+    """Check whether the action would result in a Noop action.
+
+    Args:
+        action: action representing interaction with Discourse
+
+    Returns:
+        Boolean true if the contents match, false otherwise
+    """
+    match action:
+        case types_.NoopAction(_, _, _, _):
+            return True
+        case types_.UpdateAction(_, _, _, content):
+            if not content:
+                return True
+            return content.local == content.server
+        case _:
+            return False
+
+
+def is_same_content(index: types_.Index, actions: typing.Iterable[types_.AnyAction]) -> bool:
+    """Check if the content on Discourse and Github matches.
+
+    Args:
+        index: Index object representing local and server content for the index file
+        actions: List of actions representing what the reconcile actions over all topics
+
+    Returns:
+        Boolean true if the contents match, false otherwise
+    """
+    if (not index.local) or (not index.server):
+        return False
+
+    return all(_is_same_content(action) for action in actions) and (
+        index.local.content == index_module.contents_from_page(index.server.content)
+    )
+
+
 def _local_and_server_file_local_page_server(
     path_info: types_.PathInfo,
     table_row: types_.TableRow,

--- a/src/reconcile.py
+++ b/src/reconcile.py
@@ -180,8 +180,7 @@ def _is_same_content(action: types_.AnyAction) -> bool:
             if not content:
                 return True
             return content.local == content.server
-        case _:
-            return False
+    return False
 
 
 def is_same_content(index: types_.Index, actions: typing.Iterable[types_.AnyAction]) -> bool:

--- a/tests/integration/test___init__run_conflict.py
+++ b/tests/integration/test___init__run_conflict.py
@@ -211,7 +211,7 @@ async def test_run_conflict(
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
     assert_substrings_in_string(
-        chain(urls, (doc_table_line_1, doc_table_line_1, "Noop", "'success'")), caplog.text
+        chain(urls, (doc_table_line_1, doc_table_line_1, "skip")), caplog.text
     )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_table_line_1 in index_topic

--- a/tests/integration/test___init__run_conflict.py
+++ b/tests/integration/test___init__run_conflict.py
@@ -210,9 +210,6 @@ async def test_run_conflict(
     urls_with_actions = reconcile_output.topics
 
     assert (urls := tuple(urls_with_actions)) == (doc_url, index_url)
-    assert_substrings_in_string(
-        chain(urls, (doc_table_line_1, doc_table_line_1, "skip")), caplog.text
-    )
     index_topic = discourse_api.retrieve_topic(url=index_url)
     assert doc_table_line_1 in index_topic
     doc_topic = discourse_api.retrieve_topic(url=doc_url)

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -182,10 +182,10 @@ def test_run_reconcile_same_content_local_and_server(
 ):
     """
     arrange: given a path with a metadata.yaml that has docs key and docs directory aligned
-        and mocked discourse (with tag and main branch aligned)
+        and mocked discourse (with tag and branch aligned)
     act: when run_reconcile is called
-    assert: then nothing is done, and the repository is tagged as the two versions are the
-        compatible.
+    assert: that nothing is done, and, depending on the branch we are at, the DOCUMENTATION_TAG
+        is updated with the current commit if we are in the base branch
     """
     repository_path = mocked_clients.repository.base_path
 
@@ -265,8 +265,10 @@ def test_run_reconcile_same_content_local_and_server(
 
     assert returned_reconcile_reports
 
+    assert "Reconcile not required to run" in caplog.text
+
     if branch_name == DEFAULT_BRANCH:
-        assert "Updating the tag" in caplog.records[0].msg
+        assert "Updating the tag" in caplog.text
         assert (
             mocked_clients.repository.tag_exists(DOCUMENTATION_TAG)
             == mocked_clients.repository.current_commit

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -200,16 +200,16 @@ def test_run_reconcile_same_content_local_and_server(
 
     Content body."""
     index_table = f"""{constants.NAVIGATION_TABLE_START}
-    | 1 | their-path-1 | [empty-navlink]() |
-    | 2 | their-file-1 | [file-navlink](/file-navlink) |"""
+    | 1 | folder | [Folder]() |
+    | 2 | their-file-1 | [file-navlink-title](/file-navlink) |"""
     index_page = f"{index_content}{index_table}"
-    navlink_page = "file-navlink-content"
+    navlink_page = "# file-navlink-title\nfile-navlink-content"
     mocked_clients.discourse.retrieve_topic.side_effect = [index_page, navlink_page]
 
     (docs_folder := mocked_clients.repository.base_path / "docs").mkdir()
     (docs_folder / "index.md").write_text(index_content)
-    (docs_folder / "their-path-1").mkdir()
-    (docs_folder / "their-path-1" / "their-file-1.md").write_text(navlink_page)
+    (docs_folder / "folder").mkdir()
+    (docs_folder / "folder" / "their-file-1.md").write_text(navlink_page)
 
     mocked_clients.repository.switch(DEFAULT_BRANCH).update_branch(
         "First document version", directory=None

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -207,9 +207,9 @@ def test_run_reconcile_same_content_local_and_server(
     mocked_clients.discourse.retrieve_topic.side_effect = [index_page, navlink_page]
 
     (docs_folder := mocked_clients.repository.base_path / "docs").mkdir()
-    (docs_folder / "index.md").write_text(index_content)
+    (index_file := docs_folder / "index.md").write_text(index_content)
     (docs_folder / "folder").mkdir()
-    (docs_folder / "folder" / "their-file-1.md").write_text(navlink_page)
+    (their_file := docs_folder / "folder" / "their-file-1.md").write_text(navlink_page)
 
     mocked_clients.repository.switch(DEFAULT_BRANCH).update_branch(
         "First document version", directory=None
@@ -227,11 +227,9 @@ def test_run_reconcile_same_content_local_and_server(
         """
         assert tag_name
 
-        if path == str((docs_folder / "index.md").relative_to(repository_path)):
+        if path == str(index_file.relative_to(repository_path)):
             return index_content
-        if path == str(
-            (docs_folder / "their-path-1" / "their-file-1.md").relative_to(repository_path)
-        ):
+        if path == str(their_file.relative_to(repository_path)):
             return navlink_page
         return ""
 

--- a/tests/unit/test___init__.py
+++ b/tests/unit/test___init__.py
@@ -169,6 +169,116 @@ def test__run_reconcile_local_empty_server(mocked_clients):
     }
 
 
+@mock.patch("src.repository.Client.get_file_content_from_tag")
+@pytest.mark.parametrize(
+    "branch_name",
+    [pytest.param(DEFAULT_BRANCH), pytest.param("other-main")],
+)
+def test_run_reconcile_same_content_local_and_server(
+    get_file_content_from_tag,
+    caplog,
+    mocked_clients,
+    branch_name,
+):
+    """
+    arrange: given a path with a metadata.yaml that has docs key and docs directory aligned
+        and mocked discourse (with tag and main branch aligned)
+    act: when run_reconcile is called
+    assert: then nothing is done, and the repository is tagged as the two versions are the
+        compatible.
+    """
+    repository_path = mocked_clients.repository.base_path
+
+    if branch_name != DEFAULT_BRANCH:
+        mocked_clients.repository.create_branch(branch_name, DEFAULT_BRANCH)
+
+    create_metadata_yaml(
+        content=f"{METADATA_NAME_KEY}: name 1\n" f"{METADATA_DOCS_KEY}: https://discourse/t/docs",
+        path=repository_path,
+    )
+    index_content = """Content header lorem.
+
+    Content body."""
+    index_table = f"""{constants.NAVIGATION_TABLE_START}
+    | 1 | their-path-1 | [empty-navlink]() |
+    | 2 | their-file-1 | [file-navlink](/file-navlink) |"""
+    index_page = f"{index_content}{index_table}"
+    navlink_page = "file-navlink-content"
+    mocked_clients.discourse.retrieve_topic.side_effect = [index_page, navlink_page]
+
+    (docs_folder := mocked_clients.repository.base_path / "docs").mkdir()
+    (docs_folder / "index.md").write_text(index_content)
+    (docs_folder / "their-path-1").mkdir()
+    (docs_folder / "their-path-1" / "their-file-1.md").write_text(navlink_page)
+
+    mocked_clients.repository.switch(DEFAULT_BRANCH).update_branch(
+        "First document version", directory=None
+    )
+
+    def patch(path, tag_name) -> str:
+        """Return the patches content of a given tag.
+
+        Args:
+            path: path of the file
+            tag_name: name of the tag
+
+        Returns:
+            Content of the given tag
+        """
+        assert tag_name
+
+        if path == str((docs_folder / "index.md").relative_to(repository_path)):
+            return index_content
+        if path == str(
+            (docs_folder / "their-path-1" / "their-file-1.md").relative_to(repository_path)
+        ):
+            return navlink_page
+        return ""
+
+    get_file_content_from_tag.side_effect = patch
+
+    mocked_clients.repository.tag_commit(
+        DOCUMENTATION_TAG, mocked_clients.repository.current_commit
+    )
+
+    (mocked_clients.repository.base_path / "placeholder.md").touch()
+
+    mocked_clients.repository.switch(DEFAULT_BRANCH).update_branch(
+        "Placeholder modification outside of docs", directory=None
+    )
+
+    user_inputs = factories.UserInputsFactory(
+        commit_sha=mocked_clients.repository.current_commit, base_branch=branch_name
+    )
+
+    assert (
+        mocked_clients.repository.tag_exists(DOCUMENTATION_TAG)
+        != mocked_clients.repository.current_commit
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.INFO):
+        # run is repeated in unit tests / integration tests
+        returned_reconcile_reports = run_reconcile(
+            clients=mocked_clients, user_inputs=user_inputs
+        )  # pylint: disable=duplicate-code
+
+    assert returned_reconcile_reports
+
+    if branch_name == DEFAULT_BRANCH:
+        assert "Updating the tag" in caplog.records[0].msg
+        assert (
+            mocked_clients.repository.tag_exists(DOCUMENTATION_TAG)
+            == mocked_clients.repository.current_commit
+        )
+    else:
+        # Running outside of base branch
+        assert (
+            mocked_clients.repository.tag_exists(DOCUMENTATION_TAG)
+            != mocked_clients.repository.current_commit
+        )
+
+
 @mock.patch(
     "src.repository.Client.metadata",
     types_.Metadata(name="name 1", docs=None),

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1041,42 +1041,14 @@ def test_index_page(
 @pytest.mark.parametrize(
     "actions, expected_value",
     [
-        pytest.param(
-            [types_.NoopAction(1, tuple("path"), types_.Navlink("title", None, True), None)],
-            True,
-            id="Noop action",
-        ),
-        pytest.param(
-            [types_.CreateAction(1, tuple("path"), "title", None, True)], False, id="Create action"
-        ),
-        pytest.param(
-            [types_.DeleteAction(1, tuple("path"), types_.Navlink("title", None, True), None)],
-            False,
-            id="Delete action",
-        ),
+        pytest.param([factories.NoopActionFactory()], True, id="Noop action"),
+        pytest.param([factories.CreateActionFactory], False, id="Create action"),
+        pytest.param([factories.DeleteActionFactory], False, id="Delete action"),
+        pytest.param([factories.UpdateActionFactory], False, id="Update action"),
         pytest.param(
             [
-                types_.UpdateAction(
-                    1,
-                    tuple("path"),
-                    types_.NavlinkChange(
-                        types_.Navlink("title", None, True), types_.Navlink("title", None, True)
-                    ),
-                    types_.ContentChange(None, "one", "two"),
-                )
-            ],
-            False,
-            id="Update action with different content",
-        ),
-        pytest.param(
-            [
-                types_.UpdateAction(
-                    1,
-                    tuple("path"),
-                    types_.NavlinkChange(
-                        types_.Navlink("title", None, True), types_.Navlink("title", None, True)
-                    ),
-                    types_.ContentChange(None, "same", "same"),
+                factories.UpdateActionFactory(
+                    content_change=types_.ContentChange(None, "same", "same")
                 )
             ],
             False,

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -1031,7 +1031,7 @@ def test_index_page(
                     types_.ContentChange(None, "same", "same"),
                 )
             ],
-            True,
+            False,
             id="Update action with same content",
         ),
     ],

--- a/tests/unit/test_reconcile.py
+++ b/tests/unit/test_reconcile.py
@@ -994,12 +994,17 @@ def test_index_page(
     "actions, expected_value",
     [
         pytest.param(
-            [types_.NoopAction(1, tuple("path"), types_.Navlink("title", None, True), None)], True
+            [types_.NoopAction(1, tuple("path"), types_.Navlink("title", None, True), None)],
+            True,
+            id="Noop action",
         ),
-        pytest.param([types_.CreateAction(1, tuple("path"), "title", None, True)], False),
+        pytest.param(
+            [types_.CreateAction(1, tuple("path"), "title", None, True)], False, id="Create action"
+        ),
         pytest.param(
             [types_.DeleteAction(1, tuple("path"), types_.Navlink("title", None, True), None)],
             False,
+            id="Delete action",
         ),
         pytest.param(
             [
@@ -1013,6 +1018,7 @@ def test_index_page(
                 )
             ],
             False,
+            id="Update action with different content",
         ),
         pytest.param(
             [
@@ -1026,6 +1032,7 @@ def test_index_page(
                 )
             ],
             True,
+            id="Update action with same content",
         ),
     ],
 )
@@ -1033,7 +1040,7 @@ def test__is_same_content_actions(
     actions: typing.Iterable[types_.AnyAction], expected_value: bool
 ):
     """
-    arrange: given some mock list of actions
+    arrange: given some mock list of actions and an index with matching local and server content
     act: when is_same_content function is called
     assert: then the correct results is returned.
     """
@@ -1056,6 +1063,7 @@ def test__is_same_content_actions(
                 "charm",
             ),
             True,
+            id="same index",
         ),
         pytest.param(
             types_.Index(
@@ -1064,12 +1072,14 @@ def test__is_same_content_actions(
                 "charm",
             ),
             False,
+            id="different index",
         ),
         pytest.param(
             types_.Index(
                 None, types_.IndexFile("index-title", "index-content-different"), "charm"
             ),
             False,
+            id="missing server content",
         ),
         pytest.param(
             types_.Index(
@@ -1078,12 +1088,13 @@ def test__is_same_content_actions(
                 "charm",
             ),
             False,
+            id="missing local content",
         ),
     ],
 )
 def test__is_same_content_index(index: types_.Index, expected_value: bool):
     """
-    arrange: given some mock Index object
+    arrange: given some mock Index object and an action list that only contains a NoopAction
     act: when is_same_content function is called
     assert: then the correct results is returned.
     """


### PR DESCRIPTION
In this PR, I propose a feature to keep updating the base-content tag when reconcile shows that there is no difference between Github and Discourse. 

This feature should allow to enable one way Discourse -> Github sync, even when actions have dry-run flag enabled, to prevent to push content to discourse. 