### PR TITLE
Fix empty commit sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Support for defining a contents index in the `index.md` file.
 
+### Fixed
+
+- No longer use empty values from `INPUT_COMMIT_SHA` instead of reading the
+  event/ environment
+
 ## [v0.6.0] - 2023-07-07
 
 ### Added

--- a/main.py
+++ b/main.py
@@ -59,6 +59,12 @@ def _parse_env_vars() -> types_.UserInputs:
             # Use the commit SHA if not running as a pull request
             commit_sha = os.environ["GITHUB_SHA"]
 
+    if not commit_sha:
+        raise exceptions.InputError(
+            "No valid value for the commit sha found in the input, event information or the "
+            "environment, is this action running on GitHub?"
+        )
+
     logging.info("Base branch: %s (commit %s)", base_branch, commit_sha)
 
     return types_.UserInputs(

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ def _parse_env_vars() -> types_.UserInputs:
             "Path to GitHub event information not found, is this action running on GitHub?"
         )
     event = json.loads(pathlib.Path(event_path).read_text(encoding="utf-8"))
-    if commit_sha is None:
+    if not commit_sha:
         try:
             commit_sha = event["pull_request"]["head"]["sha"]
         except KeyError:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Fixes a bug where an empty value from `INPUT_COMMIT_SHA` was used instead of correctly reading the environment or event information.

### Rationale

Ensures that the correct commit SHA is being used in the action.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

This is not a charm, the `src-docs` will be added in a separate PR