### PR TITLE
[MISC] Fixing bug arising when repositories are shallow

### DIFF
--- a/src/repository.py
+++ b/src/repository.py
@@ -280,8 +280,8 @@ class Client:  # pylint: disable=too-many-public-methods
         """
         star_pattern = re.compile(r"^\* ")
         try:
-            # This effectively means preventing a shallow repository to behave correctly. Note that
-            # the special depth 2147483647 (or 0x7fffffff, the largest positive number a
+            # This effectively means preventing a shallow repository to not behave correctly.
+            # Note that the special depth 2147483647 (or 0x7fffffff, the largest positive number a
             # signed 32-bit integer can contain) means infinite depth.
             # Reference: https://git-scm.com/docs/shallow
             self._git_repo.git.fetch("--depth=2147483647")

--- a/src/repository.py
+++ b/src/repository.py
@@ -280,6 +280,10 @@ class Client:  # pylint: disable=too-many-public-methods
         """
         star_pattern = re.compile(r"^\* ")
         try:
+            # This effectively means preventing a shallow repository to behave correctly. Note that
+            # the special depth 2147483647 (or 0x7fffffff, the largest positive number a
+            # signed 32-bit integer can contain) means infinite depth.
+            # Reference: https://git-scm.com/docs/shallow
             self._git_repo.git.fetch("--depth=2147483647")
             branches_with_commit = {
                 star_pattern.sub("", _branch).strip()

--- a/src/repository.py
+++ b/src/repository.py
@@ -280,6 +280,7 @@ class Client:  # pylint: disable=too-many-public-methods
         """
         star_pattern = re.compile(r"^\* ")
         try:
+            self._git_repo.git.fetch("--depth=2147483647")
             branches_with_commit = {
                 star_pattern.sub("", _branch).strip()
                 for _branch in self._git_repo.git.branch("--contains", commit_sha).split("\n")


### PR DESCRIPTION
The actions are most-likely failing across repositories, since we have introduced a check to make sure that tags do indeed belong to the base branch. 

However, git repositories in Github Actions are shallow, only carrying a single commit. Therefore, the checks may erroneously fail since the documentation tag commit is unknown to the base branch. 

While doing this I have also slightly refactored the `pre_flight_check` to provide some more meaningful logging